### PR TITLE
Fix Job tracker hangs sometime

### DIFF
--- a/pkg/tracker/daemonset/tracker.go
+++ b/pkg/tracker/daemonset/tracker.go
@@ -359,6 +359,9 @@ func (d *Tracker) runPodTracker(ctx context.Context, podName string) error {
 			case status := <-podTracker.Succeeded:
 				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
 				cancelPodCtx()
+			case status := <-podTracker.Deleted:
+				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
+				cancelPodCtx()
 			case report := <-podTracker.Failed:
 				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: report.PodStatus}
 			case status := <-podTracker.Ready:

--- a/pkg/tracker/deployment/tracker.go
+++ b/pkg/tracker/deployment/tracker.go
@@ -479,6 +479,9 @@ func (d *Tracker) runPodTracker(_ctx context.Context, podName, rsName string) er
 			case status := <-podTracker.Succeeded:
 				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
 				cancelPodCtx()
+			case status := <-podTracker.Deleted:
+				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
+				cancelPodCtx()
 			case report := <-podTracker.Failed:
 				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: report.PodStatus}
 			case status := <-podTracker.Ready:

--- a/pkg/tracker/job/tracker.go
+++ b/pkg/tracker/job/tracker.go
@@ -373,6 +373,9 @@ func (job *Tracker) runPodTracker(_ctx context.Context, podName string) error {
 			case status := <-podTracker.Succeeded:
 				job.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
 				cancelPodCtx()
+			case status := <-podTracker.Deleted:
+				job.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
+				cancelPodCtx()
 			case status := <-podTracker.Ready:
 				job.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
 			case report := <-podTracker.Failed:

--- a/pkg/tracker/pod/tracker.go
+++ b/pkg/tracker/pod/tracker.go
@@ -57,6 +57,7 @@ type Tracker struct {
 	tracker.Tracker
 
 	Added     chan PodStatus
+	Deleted   chan PodStatus
 	Succeeded chan PodStatus
 	Ready     chan PodStatus
 	Failed    chan FailedReport
@@ -98,6 +99,7 @@ func NewTracker(name, namespace string, kube kubernetes.Interface) *Tracker {
 		},
 
 		Added:     make(chan PodStatus, 1),
+		Deleted:   make(chan PodStatus, 0),
 		Succeeded: make(chan PodStatus, 0),
 		Ready:     make(chan PodStatus, 0),
 		Failed:    make(chan FailedReport, 0),
@@ -155,7 +157,7 @@ func (pod *Tracker) Start(ctx context.Context) error {
 				pod.ContainerTrackerStates[k] = tracker.ContainerTrackerDone
 			}
 
-			pod.Status <- status
+			pod.Deleted <- status
 
 		case reason := <-pod.objectFailed:
 			pod.State = tracker.ResourceFailed

--- a/pkg/tracker/statefulset/tracker.go
+++ b/pkg/tracker/statefulset/tracker.go
@@ -370,6 +370,9 @@ func (d *Tracker) runPodTracker(_ctx context.Context, podName string) error {
 			case status := <-podTracker.Succeeded:
 				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
 				cancelPodCtx()
+			case status := <-podTracker.Deleted:
+				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: status}
+				cancelPodCtx()
 			case report := <-podTracker.Failed:
 				d.podStatusesRelay <- map[string]pod.PodStatus{podTracker.ResourceName: report.PodStatus}
 			case status := <-podTracker.Ready:


### PR DESCRIPTION
The issue occured when deleting a Pod of the Job. Then Job tracker starts tracking newly created Pod, but a tracker for old Pod has not been stopped properly in some condition.

Added Deleted channel to the Pod tracker, added handling of Pod deletion to Job, StatefulSet, DaemonSet and Deployment trackers.

fixes https://github.com/werf/kubedog/issues/127
