### PR TITLE
Rework elimination tracker

### DIFF
--- a/pkg/tracker/pod/tracker.go
+++ b/pkg/tracker/pod/tracker.go
@@ -391,7 +391,7 @@ func (pod *Tracker) trackContainer(ctx context.Context, containerName string) er
 	for {
 		select {
 		case <-ticker.C:
-			state := pod.ContainerTrackerStates[containerName]
+			state := pod.ContainerTrackerStates[containerName] // PANIC HERE
 
 			switch state {
 			case tracker.FollowingContainerLogs:


### PR DESCRIPTION
 - Use list operation to check object existance.
 - Use list informer delete event to watch until object deleted.

This fix needed to correctly implement --with-namespace option for the werf-dismiss command.