### PR TITLE
Fix multitracker exited before ready issue

### DIFF
--- a/pkg/trackers/elimination/elimination.go
+++ b/pkg/trackers/elimination/elimination.go
@@ -82,7 +82,7 @@ func TrackUntilEliminated(ctx context.Context, kubeDynamicClient dynamic.Interfa
 	}
 
 	var errors []error
-	var pendingJobs = len(specs)
+	pendingJobs := len(specs)
 	for {
 		select {
 		case err := <-errorChan:
@@ -102,6 +102,9 @@ func TrackUntilEliminated(ctx context.Context, kubeDynamicClient dynamic.Interfa
 				return nil
 			}
 		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
 			return ctx.Err()
 		}
 	}

--- a/pkg/trackers/rollout/multitrack/debug.go
+++ b/pkg/trackers/rollout/multitrack/debug.go
@@ -1,7 +1,0 @@
-package multitrack
-
-import "os"
-
-func debug() bool {
-	return os.Getenv("KUBEDOG_ROLLOUT_MULTITRACK_DEBUG") == "1"
-}


### PR DESCRIPTION
Context cancelled error was not suppressed properly in lowlevel pod-tracker and was ignored in multitracker.