### PR TITLE
[for werf v1.1] Fix multitracker exited before ready issue

### DIFF
--- a/pkg/tracker/pod/tracker.go
+++ b/pkg/tracker/pod/tracker.go
@@ -157,6 +157,10 @@ func (pod *Tracker) Start(ctx context.Context) error {
 				pod.ContainerTrackerStates[k] = tracker.ContainerTrackerDone
 			}
 
+			if debug.Debug() {
+				fmt.Printf("Pod %q deleted status: %#v\n", pod.ResourceName, status)
+			}
+
 			pod.Deleted <- status
 
 		case reason := <-pod.objectFailed:
@@ -190,15 +194,22 @@ func (pod *Tracker) Start(ctx context.Context) error {
 			}
 
 		case <-ctx.Done():
+			if debug.Debug() {
+				fmt.Printf("pod tracker %s context done: %v\n", pod.ResourceName, ctx.Err())
+			}
+
 			if ctx.Err() == context.Canceled {
 				return nil
 			}
 			return ctx.Err()
 		case err := <-pod.errors:
+			if debug.Debug() {
+				fmt.Printf("pod tracker %s error received! err=%v\n", pod.ResourceName, err)
+			}
+
 			return err
 		}
 	}
-
 }
 
 func (pod *Tracker) handlePodState(ctx context.Context, object *corev1.Pod) error {
@@ -378,6 +389,9 @@ func (pod *Tracker) followContainerLogs(ctx context.Context, containerName strin
 
 		select {
 		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
 			return ctx.Err()
 		default:
 		}
@@ -412,6 +426,13 @@ func (pod *Tracker) trackContainer(ctx context.Context, containerName string) er
 			}
 
 		case <-ctx.Done():
+			if debug.Debug() {
+				fmt.Printf("-- trackContainer context done -> %v\n", ctx.Err())
+			}
+
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
 			return ctx.Err()
 		}
 	}

--- a/pkg/trackers/elimination/elimination.go
+++ b/pkg/trackers/elimination/elimination.go
@@ -83,7 +83,7 @@ func TrackUntilEliminated(ctx context.Context, kubeDynamicClient dynamic.Interfa
 	}
 
 	var errors []error
-	var pendingJobs = len(specs)
+	pendingJobs := len(specs)
 	for {
 		select {
 		case err := <-errorChan:
@@ -103,6 +103,9 @@ func TrackUntilEliminated(ctx context.Context, kubeDynamicClient dynamic.Interfa
 				return nil
 			}
 		case <-ctx.Done():
+			if ctx.Err() == context.Canceled {
+				return nil
+			}
 			return ctx.Err()
 		}
 	}

--- a/pkg/trackers/rollout/multitrack/debug.go
+++ b/pkg/trackers/rollout/multitrack/debug.go
@@ -1,7 +1,0 @@
-package multitrack
-
-import "os"
-
-func debug() bool {
-	return os.Getenv("KUBEDOG_ROLLOUT_MULTITRACK_DEBUG") == "1"
-}


### PR DESCRIPTION
Context cancelled error was not suppressed properly in lowlevel pod-tracker and was ignored in multitracker.