### PR TITLE
infra: use gox parallel release build tool

### DIFF
--- a/scripts/ci/build_release_v2.sh
+++ b/scripts/ci/build_release_v2.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+VERSION=$1
+if [ -z "$VERSION" ] ; then
+    echo "Required version argument!" 1>&2
+    echo 1>&2
+    echo "Usage: $0 VERSION" 1>&2
+    exit 1
+fi
+
+gox -osarch="linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64" \
+    -output="release-build/$VERSION/{{.OS}}-{{.Arch}}/kubedog" \
+    -ldflags="-s -w -X github.com/werf/kubedog.Version=$VERSION" \
+        github.com/werf/kubedog/cmd/kubedog

--- a/trdl.yaml
+++ b/trdl.yaml
@@ -1,3 +1,3 @@
-docker_image: golang:1.16.4@sha256:f7a5c5872d4bb68e152be72e4a4bf9a142a47ec2dcbb4074798d4feb6197abd7
+docker_image: golang:1.17-alpine@sha256:13919fb9091f6667cb375d5fdf016ecd6d3a5d5995603000d422b04583de4ef9
 commands:
-- ./scripts/ci/build_release.sh {{ .Tag }} && cp -a release-build/{{ .Tag }}/* /result
+- ./scripts/ci/build_release_v2.sh {{ .Tag }} && cp -a release-build/{{ .Tag }}/* /result


### PR DESCRIPTION
 - New script scripts/ci/build_release_v2.sh uses gox build tool to create release binaries.
 - Update trdl.yaml to use new build tool.