### PR TITLE
fix: non-blocking mode doesn't work

### DIFF
--- a/pkg/trackers/rollout/multitrack/multitrack.go
+++ b/pkg/trackers/rollout/multitrack/multitrack.go
@@ -423,6 +423,10 @@ func (mt *multitracker) applyTrackTerminationMode() error {
 		contextsToStop = append(contextsToStop, ctx)
 	}
 	for _, res := range mt.GenericResources {
+		if res.Context == nil {
+			continue
+		}
+
 		if res.Spec.TrackTerminationMode == generic.WaitUntilResourceReady {
 			return nil
 		}


### PR DESCRIPTION
Broken because of new generic tracking feature changes.

Signed-off-by: Ilya Lesikov <ilya@lesikov.com>