### PR TITLE
fix: pods not readying thus task not ready

### DIFF
--- a/pkg/trackers/dyntracker/dynamic_readiness_tracker.go
+++ b/pkg/trackers/dyntracker/dynamic_readiness_tracker.go
@@ -976,6 +976,8 @@ func (t *DynamicReadinessTracker) handleDeploymentStatus(status *deployment.Depl
 	}
 
 	if status.IsReady {
+		taskState.SetStatus(statestore.ReadinessTaskStatusReady)
+
 		for _, state := range taskState.ResourceStates() {
 			state.RWTransaction(func(rs *statestore.ResourceState) {
 				rs.SetStatus(statestore.ResourceStatusReady)
@@ -1000,6 +1002,8 @@ func (t *DynamicReadinessTracker) handleStatefulSetStatus(status *statefulset.St
 	}
 
 	if status.IsReady {
+		taskState.SetStatus(statestore.ReadinessTaskStatusReady)
+
 		for _, state := range taskState.ResourceStates() {
 			state.RWTransaction(func(rs *statestore.ResourceState) {
 				rs.SetStatus(statestore.ResourceStatusReady)
@@ -1024,6 +1028,8 @@ func (t *DynamicReadinessTracker) handleDaemonSetStatus(status *daemonset.Daemon
 	}
 
 	if status.IsReady {
+		taskState.SetStatus(statestore.ReadinessTaskStatusReady)
+
 		for _, state := range taskState.ResourceStates() {
 			state.RWTransaction(func(rs *statestore.ResourceState) {
 				rs.SetStatus(statestore.ResourceStatusReady)
@@ -1046,6 +1052,8 @@ func (t *DynamicReadinessTracker) handleJobStatus(status *job.JobStatus, taskSta
 	}
 
 	if status.IsSucceeded {
+		taskState.SetStatus(statestore.ReadinessTaskStatusReady)
+
 		for _, state := range taskState.ResourceStates() {
 			state.RWTransaction(func(rs *statestore.ResourceState) {
 				rs.SetStatus(statestore.ResourceStatusReady)
@@ -1064,6 +1072,8 @@ func (t *DynamicReadinessTracker) handleCanaryStatus(status *canary.CanaryStatus
 	}
 
 	if status.IsSucceeded {
+		taskState.SetStatus(statestore.ReadinessTaskStatusReady)
+
 		for _, state := range taskState.ResourceStates() {
 			state.RWTransaction(func(rs *statestore.ResourceState) {
 				rs.SetStatus(statestore.ResourceStatusReady)
@@ -1088,6 +1098,8 @@ func (t *DynamicReadinessTracker) handleGenericResourceStatus(status *generic.Re
 	}
 
 	if status.IsReady() {
+		taskState.SetStatus(statestore.ReadinessTaskStatusReady)
+
 		for _, state := range taskState.ResourceStates() {
 			state.RWTransaction(func(rs *statestore.ResourceState) {
 				rs.SetStatus(statestore.ResourceStatusReady)

--- a/pkg/trackers/dyntracker/statestore/absence_task_state.go
+++ b/pkg/trackers/dyntracker/statestore/absence_task_state.go
@@ -15,6 +15,7 @@ type AbsenceTaskState struct {
 	absentConditions  []AbsenceTaskConditionFn
 	failureConditions []AbsenceTaskConditionFn
 
+	status        AbsenceTaskStatus
 	uuid          string
 	resourceState *util.Concurrent[*ResourceState]
 }
@@ -56,7 +57,15 @@ func (s *AbsenceTaskState) ResourceState() *util.Concurrent[*ResourceState] {
 	return s.resourceState
 }
 
+func (s *AbsenceTaskState) SetStatus(status AbsenceTaskStatus) {
+	s.status = status
+}
+
 func (s *AbsenceTaskState) Status() AbsenceTaskStatus {
+	if s.status != "" {
+		return s.status
+	}
+
 	for _, failureCondition := range s.failureConditions {
 		if failureCondition(s) {
 			return AbsenceTaskStatusFailed

--- a/pkg/trackers/dyntracker/statestore/presence_task_state.go
+++ b/pkg/trackers/dyntracker/statestore/presence_task_state.go
@@ -15,6 +15,7 @@ type PresenceTaskState struct {
 	presentConditions []PresenceTaskConditionFn
 	failureConditions []PresenceTaskConditionFn
 
+	status        PresenceTaskStatus
 	uuid          string
 	resourceState *util.Concurrent[*ResourceState]
 }
@@ -56,7 +57,15 @@ func (s *PresenceTaskState) ResourceState() *util.Concurrent[*ResourceState] {
 	return s.resourceState
 }
 
+func (s *PresenceTaskState) SetStatus(status PresenceTaskStatus) {
+	s.status = status
+}
+
 func (s *PresenceTaskState) Status() PresenceTaskStatus {
+	if s.status != "" {
+		return s.status
+	}
+
 	for _, failureCondition := range s.failureConditions {
 		if failureCondition(s) {
 			return PresenceTaskStatusFailed

--- a/pkg/trackers/dyntracker/statestore/readiness_task_state.go
+++ b/pkg/trackers/dyntracker/statestore/readiness_task_state.go
@@ -20,6 +20,7 @@ type ReadinessTaskState struct {
 	readyConditions   []ReadinessTaskConditionFn
 	failureConditions []ReadinessTaskConditionFn
 
+	status             ReadinessTaskStatus
 	uuid               string
 	resourceStatesTree domigraph.Graph[string, *util.Concurrent[*ResourceState]]
 }
@@ -127,7 +128,15 @@ func (s *ReadinessTaskState) TraverseResourceStates(fromName, fromNamespace stri
 	return states
 }
 
+func (s *ReadinessTaskState) SetStatus(status ReadinessTaskStatus) {
+	s.status = status
+}
+
 func (s *ReadinessTaskState) Status() ReadinessTaskStatus {
+	if s.status != "" {
+		return s.status
+	}
+
 	for _, failureCondition := range s.failureConditions {
 		if failureCondition(s) {
 			return ReadinessTaskStatusFailed


### PR DESCRIPTION
Sometimes final Ready event comes from low-level trackers too early, before e.g. Pods are even added to StateStore. This forces to Task to go to Ready state regardless of Pods.