### PR TITLE
fix: consider init container error on tracking

### DIFF
--- a/pkg/tracker/pod/status.go
+++ b/pkg/tracker/pod/status.go
@@ -145,6 +145,16 @@ func NewPodStatus(pod *corev1.Pod, statusGeneration uint64, trackedContainers []
 }
 
 func setContainersStatusesToPodStatus(status *PodStatus, pod *corev1.Pod) {
+	for _, cs := range pod.Status.InitContainerStatuses {
+		if cs.State.Terminated != nil {
+			switch cs.State.Terminated.Reason {
+			case "Error":
+				status.IsFailed = true
+				status.FailedReason = cs.State.Terminated.Reason
+			}
+		}
+	}
+
 	allContainerStatuses := make([]corev1.ContainerStatus, 0)
 	allContainerStatuses = append(allContainerStatuses, pod.Status.InitContainerStatuses...)
 	allContainerStatuses = append(allContainerStatuses, pod.Status.ContainerStatuses...)


### PR DESCRIPTION
First-time init container errors on Job deployment cause constant tracking of failed containers, even if the next Job pod succeeds.

**Steps to reproduce**

See the sample job manifest below. Change http://192.168.0.246 to your local test web server, and make sure it is unavailable at the start.

```
---
apiVersion: batch/v1
kind: Job
metadata:
  name: example-job-init-failed
  annotations:
    "helm.sh/hook": "pre-install,pre-upgrade"
spec:
  completions: 1
  parallelism: 1
  template:
    spec:
      initContainers:
      - name: init
        image: alpine/curl
        command: ['sh', '-c', 'echo Init container running; sleep 15; curl -fs -m 5 http://192.168.0.246']
      containers:
      - name: main
        image: alpine/curl
        command: ['sh', '-c', 'echo Main container running; sleep 15; curl -fs -m 5 http://192.168.0.246']
      restartPolicy: Never
  backoffLimit: 1
```

Deploy with `werf converge`:

```
<skipped>
┌ Progress status
│ RESOURCE (→READY)                     STATE    INFO
│ Job/example-job-init-failed           WAITING  Ready:0/1
│  • Pod/example-job-init-failed-qscgn  UNKNOWN  Status:Init:0/1
└ Progress status

┌ Progress status
│ RESOURCE (→READY)                     STATE    INFO
│ Job/example-job-init-failed           WAITING  Ready:0/1
│  • Pod/example-job-init-failed-qscgn  UNKNOWN  Status:Init:Error
└ Progress status
```  

When you see that the init container failed first time, make your webserver available. The job should succeed from the second try:

```
<skipped>
┌ Progress status
│ RESOURCE (→READY)                     STATE    INFO
│ Job/example-job-init-failed           WAITING  Ready:0/1
│  • Pod/example-job-init-failed-qscgn  UNKNOWN  Status:Init:Error
│  • Pod/example-job-init-failed-q84hl  UNKNOWN  Status:PodInitializing
└ Progress status

┌ Progress status
│ RESOURCE (→READY)                     STATE    INFO
│ Job/example-job-init-failed           WAITING  Ready:0/1
│  • Pod/example-job-init-failed-q84hl  UNKNOWN  Status:Running
│  • Pod/example-job-init-failed-qscgn  UNKNOWN  Status:Init:Error
└ Progress status

┌ Progress status
│ RESOURCE (→READY)                     STATE    INFO
│ Job/example-job-init-failed           WAITING  Ready:0/1
│  • Pod/example-job-init-failed-qscgn  UNKNOWN  Status:Init:Error
│  • Pod/example-job-init-failed-q84hl  UNKNOWN  Status:Completed
└ Progress status
```

Next, the latest block will be constantly repeated due to bug.



