### PR TITLE
fix: truncate overly long container log lines from pod logs

### DIFF
--- a/pkg/tracker/pod/tracker.go
+++ b/pkg/tracker/pod/tracker.go
@@ -28,6 +28,8 @@ import (
 
 var errLogStreamingTimeout = errors.New("log streaming timeout reached")
 
+const containerLogLineLengthLimit = 64 * 1024
+
 type ContainerError struct {
 	Message       string
 	ContainerName string
@@ -451,6 +453,7 @@ func (pod *Tracker) followContainerLogs(ctx context.Context, containerName strin
 
 	chunkBuf := make([]byte, 1024*64)
 	lineBuf := make([]byte, 0, 1024*4)
+	var lineTruncated bool
 
 	for {
 		n, err := readCloser.Read(chunkBuf)
@@ -464,11 +467,21 @@ func (pod *Tracker) followContainerLogs(ctx context.Context, containerName strin
 					line := string(lineBuf)
 					lineBuf = lineBuf[:0]
 
+					if lineTruncated {
+						line += fmt.Sprintf(" [truncated by kubedog: line exceeded %d bytes]", containerLogLineLengthLimit)
+						lineTruncated = false
+					}
+
 					lineParts := strings.SplitN(line, " ", 2)
 					if len(lineParts) == 2 {
 						chunkLines = append(chunkLines, display.LogLine{Timestamp: lineParts[0], Message: lineParts[1]})
 					}
 
+					continue
+				}
+
+				if len(lineBuf) >= containerLogLineLengthLimit {
+					lineTruncated = true
 					continue
 				}
 


### PR DESCRIPTION
kubedog now caps a single container log line at 64 KiB when it reads Pod logs from the Kubernetes API, truncating anything longer instead of buffering it without limit, so one oversized line can no longer freeze log tracking.

Previously `followContainerLogs` accumulated each log line into a buffer unbounded until it saw a newline, then handed the whole line to the logging pipeline. When a line was very long this broke in one of two ways:
- the logging library `logboek` stalls while rendering the huge line; the consumer stops draining the buffered `ContainerLogChunk` channel (capacity 1000), the channel fills up, the blocking send stops the log-stream reader goroutine, and the whole tracking pipeline freezes until the context times out (the hang reported in #381 for `nelm release install` output)
- a stream that never emits a newline grows the buffer without bound, with no upper limit on memory use

The read loop already pulls log data in 64 KiB chunks into a line buffer. This adds a `containerLogLineLengthLimit` of 64 KiB (the size of that read buffer) and enforces it per line: once a line reaches the limit kubedog stops appending bytes but keeps scanning until the newline, so log parsing stays in sync, and a flag carried across chunk reads records that the line was cut. When the line is flushed it gets a short marker before the timestamp/message split, so the marker lands in the message body:
```
 [truncated by kubedog: line exceeded 65536 bytes]
```

The line is truncated, not dropped - the visible part is still shown and only the overflow is discarded. Reading with a limit through the Kubernetes API itself does not help here: `PodLogOptions.LimitBytes` caps the total bytes of the whole stream, not the length of an individual line, so it cannot express "trim each line".

`followContainerLogs` is the single place every tracker reads container logs — the Job tracker has no log loop of its own and reuses the Pod tracker — so this also covers #158, where a long line in a job's pod output hangs job tracking. The underlying problem lives in the logging library (werf/logboek#73); this change is a guard on the kubedog side so a single misbehaving container cannot freeze tracking regardless of the renderer.

Verified with `go build ./...`, `go vet` and `golangci-lint` clean, and the read-loop logic checked against a standalone replica across boundary cases: a line exactly at the limit is not marked, one byte over it is, the truncation flag is carried across chunk boundaries, a stream with no newline keeps memory bounded at the limit, a multi-byte rune cut mid-character does not panic, and multiple lines in one chunk are split correctly.

Closes #381
Refs #158