### PR TITLE
fix: fail Deployment tracking fast on ReplicaSet pod-create errors

### DIFF
--- a/pkg/dyntracker/dynamic_readiness_tracker.go
+++ b/pkg/dyntracker/dynamic_readiness_tracker.go
@@ -1186,6 +1186,9 @@ func (t *DynamicReadinessTracker) handleDeploymentStatus(status *deployment.Depl
 	if status.IsFailed {
 		taskState.ResourceState(taskState.Name(), taskState.Namespace(), taskState.GroupVersionKind()).RWTransaction(func(rs *statestore.ResourceState) {
 			rs.AddError(errors.New(status.FailedReason), "", time.Now())
+			if status.FailureMode == deployment.FailureModeFatal {
+				rs.SetStatus(statestore.ResourceStatusFailed)
+			}
 		})
 	}
 }

--- a/pkg/dyntracker/dynamic_readiness_tracker_failure_mode_test.go
+++ b/pkg/dyntracker/dynamic_readiness_tracker_failure_mode_test.go
@@ -1,0 +1,87 @@
+package dyntracker
+
+import (
+	"testing"
+
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	"github.com/werf/kubedog/pkg/dyntracker/statestore"
+	"github.com/werf/kubedog/pkg/tracker/deployment"
+)
+
+func TestHandleDeploymentStatus_KeepsCountedFailureWithinAllowance(t *testing.T) {
+	taskState := statestore.NewReadinessTaskState(
+		"demo",
+		"default",
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		statestore.ReadinessTaskStateOptions{TotalAllowFailuresCount: 1},
+	)
+	status := deployment.DeploymentStatus{
+		IsFailed:     true,
+		FailedReason: "counted event failure",
+		FailureMode:  deployment.FailureModeCounted,
+	}
+
+	(&DynamicReadinessTracker{}).handleDeploymentStatus(&status, taskState)
+
+	if got := taskState.Status(); got != statestore.ReadinessTaskStatusProgressing {
+		t.Fatalf("counted failure within allowance must keep tracking progressing, got %s", got)
+	}
+}
+
+func TestHandleDeploymentStatus_FailsOnFatalFailureInLegacyFailMode(t *testing.T) {
+	taskState := statestore.NewReadinessTaskState(
+		"demo",
+		"default",
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		statestore.ReadinessTaskStateOptions{
+			FailMode:                statestore.LegacyHopeUntilEndOfDeployProcess,
+			TotalAllowFailuresCount: 1,
+		},
+	)
+	status := deployment.DeploymentStatus{
+		IsFailed:     true,
+		FailedReason: `pods "demo-111" is forbidden: exceeded quota: compute-quota`,
+		FailureMode:  deployment.FailureModeFatal,
+	}
+
+	(&DynamicReadinessTracker{}).handleDeploymentStatus(&status, taskState)
+
+	if got := taskState.Status(); got != statestore.ReadinessTaskStatusFailed {
+		t.Fatalf("fatal failure must fail tracking regardless of the allowance, got %s", got)
+	}
+}
+
+func TestHandleDeploymentStatus_KeepsFatalFailureIgnoredInIgnoreFailMode(t *testing.T) {
+	taskState := statestore.NewReadinessTaskState(
+		"demo",
+		"default",
+		schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"},
+		statestore.ReadinessTaskStateOptions{
+			FailMode:                statestore.IgnoreAndContinueDeployProcess,
+			TotalAllowFailuresCount: 0,
+		},
+	)
+	status := deployment.DeploymentStatus{
+		IsFailed:     true,
+		FailedReason: `pods "demo-111" is forbidden: exceeded quota: compute-quota`,
+		FailureMode:  deployment.FailureModeFatal,
+	}
+
+	(&DynamicReadinessTracker{}).handleDeploymentStatus(&status, taskState)
+
+	resourceState := taskState.ResourceState(taskState.Name(), taskState.Namespace(), taskState.GroupVersionKind())
+
+	var resourceStatus statestore.ResourceStatus
+	resourceState.RTransaction(func(rs *statestore.ResourceState) {
+		resourceStatus = rs.Status()
+	})
+
+	if resourceStatus != statestore.ResourceStatusFailed {
+		t.Fatalf("fatal failure must be recorded on the resource state, got %s", resourceStatus)
+	}
+
+	if got := taskState.Status(); got != statestore.ReadinessTaskStatusProgressing {
+		t.Fatalf("ignore fail mode must keep tracking progressing on a fatal failure, got %s", got)
+	}
+}

--- a/pkg/dyntracker/dynamic_readiness_tracker_replicafailure_test.go
+++ b/pkg/dyntracker/dynamic_readiness_tracker_replicafailure_test.go
@@ -1,0 +1,198 @@
+package dyntracker_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/werf/kubedog/pkg/dyntracker"
+	"github.com/werf/kubedog/pkg/dyntracker/logstore"
+	"github.com/werf/kubedog/pkg/dyntracker/statestore"
+	"github.com/werf/kubedog/pkg/dyntracker/util"
+	"github.com/werf/kubedog/pkg/informer"
+)
+
+var replicaFailureDeploymentGVK = schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "Deployment"}
+
+func TestDynamicReadinessTracker_SingleDurableReplicaFailure_TerminatesPromptly(t *testing.T) {
+	const boundedTimeout = 8 * time.Second
+
+	tests := []struct {
+		name          string
+		allowFailures int
+	}{
+		{name: "allowance below the single failure", allowFailures: 0},
+		{name: "allowance equal to the single failure", allowFailures: 1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dynClient := dynamicfake.NewSimpleDynamicClient(k8sscheme.Scheme,
+				replicaFailureOneReplicaDeployment(), replicaFailureFailedCreateReplicaSet())
+			kubeClient := k8sfake.NewSimpleClientset()
+
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			watchErrCh := make(chan error, 100)
+			factory := informer.NewConcurrentInformerFactory(ctx.Done(), watchErrCh, dynClient, informer.ConcurrentInformerFactoryOptions{})
+
+			taskState := util.NewConcurrent(statestore.NewReadinessTaskState(
+				"demo", "default", replicaFailureDeploymentGVK,
+				statestore.ReadinessTaskStateOptions{TotalAllowFailuresCount: tt.allowFailures},
+			))
+			logStore := util.NewConcurrent(logstore.NewLogStore())
+
+			rt, err := dyntracker.NewDynamicReadinessTracker(
+				ctx, taskState, logStore, factory, kubeClient, dynClient, nil, replicaFailureStubRESTMapper{},
+				dyntracker.DynamicReadinessTrackerOptions{
+					Timeout:                    boundedTimeout,
+					CaseInsensitiveGVKMatching: true,
+					IgnoreLogs:                 true,
+				},
+			)
+			if err != nil {
+				t.Fatalf("NewDynamicReadinessTracker: %v", err)
+			}
+
+			start := time.Now()
+			trackErr := rt.Track(ctx)
+			elapsed := time.Since(start)
+
+			if trackErr == nil {
+				t.Fatalf("expected Track() to fail once the durable ReplicaFailure is observed, got nil error after %s", elapsed)
+			}
+			if !strings.Contains(trackErr.Error(), "readiness failed") {
+				t.Fatalf("expected a readiness-failed error, got: %v (after %s)", trackErr, elapsed)
+			}
+			if elapsed >= boundedTimeout/2 {
+				t.Fatalf("expected prompt termination well under the %s bailout bound, took %s: %v", boundedTimeout, elapsed, trackErr)
+			}
+
+			const expectedDiagnostic = `pods "demo-111" is forbidden: exceeded quota: compute-quota`
+			var diagnosticFound bool
+			taskState.RTransaction(func(state *statestore.ReadinessTaskState) {
+				resourceState := state.ResourceState(state.Name(), state.Namespace(), state.GroupVersionKind())
+				resourceState.RTransaction(func(resource *statestore.ResourceState) {
+					for _, errs := range resource.Errors() {
+						for _, resourceErr := range errs {
+							if strings.Contains(resourceErr.Err.Error(), expectedDiagnostic) {
+								diagnosticFound = true
+							}
+						}
+					}
+				})
+			})
+			if !diagnosticFound {
+				t.Fatalf("task state does not retain ReplicaSet diagnostic %q", expectedDiagnostic)
+			}
+		})
+	}
+}
+
+func replicaFailureOneReplicaDeployment() *appsv1.Deployment {
+	one := int32(1)
+	return &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: "default", UID: "dep-uid-1", Generation: 1},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox:1"}}},
+			},
+		},
+		Status: appsv1.DeploymentStatus{ObservedGeneration: 1},
+	}
+}
+
+func replicaFailureFailedCreateReplicaSet() *appsv1.ReplicaSet {
+	one := int32(1)
+	isController := true
+	return &appsv1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-111",
+			Namespace: "default",
+			UID:       "rs-uid-1",
+			Labels:    map[string]string{"app": "demo"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: "demo", UID: "dep-uid-1", Controller: &isController,
+			}},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: &one,
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox:1"}}},
+			},
+		},
+		Status: appsv1.ReplicaSetStatus{
+			Conditions: []appsv1.ReplicaSetCondition{{
+				Type:               appsv1.ReplicaSetReplicaFailure,
+				Status:             corev1.ConditionTrue,
+				Reason:             "FailedCreate",
+				Message:            `pods "demo-111" is forbidden: exceeded quota: compute-quota`,
+				LastTransitionTime: metav1.Now(),
+			}},
+		},
+	}
+}
+
+type replicaFailureStubRESTMapper struct{}
+
+func (replicaFailureStubRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, errors.New("not implemented")
+}
+
+func (replicaFailureStubRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (replicaFailureStubRESTMapper) ResourceFor(schema.GroupVersionResource) (schema.GroupVersionResource, error) {
+	return schema.GroupVersionResource{}, errors.New("not implemented")
+}
+
+func (replicaFailureStubRESTMapper) ResourcesFor(schema.GroupVersionResource) ([]schema.GroupVersionResource, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (replicaFailureStubRESTMapper) RESTMapping(gk schema.GroupKind, _ ...string) (*meta.RESTMapping, error) {
+	if strings.EqualFold(gk.Group, "apps") && strings.EqualFold(gk.Kind, "deployment") {
+		return &meta.RESTMapping{
+			Resource:         schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"},
+			GroupVersionKind: replicaFailureDeploymentGVK,
+			Scope:            meta.RESTScopeNamespace,
+		}, nil
+	}
+	return nil, fmt.Errorf("replicaFailureStubRESTMapper: no mapping for %s", gk)
+}
+
+func (m replicaFailureStubRESTMapper) RESTMappings(gk schema.GroupKind, versions ...string) ([]*meta.RESTMapping, error) {
+	mapping, err := m.RESTMapping(gk, versions...)
+	if err != nil {
+		return nil, err
+	}
+	return []*meta.RESTMapping{mapping}, nil
+}
+
+func (replicaFailureStubRESTMapper) ResourceSingularizer(resource string) (string, error) {
+	return strings.TrimSuffix(resource, "s"), nil
+}
+
+func (replicaFailureStubRESTMapper) Reset() {}

--- a/pkg/dyntracker/statestore/readiness_task_state.go
+++ b/pkg/dyntracker/statestore/readiness_task_state.go
@@ -190,29 +190,33 @@ func initReadinessTaskStateReadyConditions() []ReadinessTaskConditionFn {
 func initReadinessTaskStateFailureConditions(failMode FailMode, totalAllowFailuresCount int) []ReadinessTaskConditionFn {
 	var failureConditions []ReadinessTaskConditionFn
 
-	failureConditions = append(failureConditions, func(taskState *ReadinessTaskState) bool {
-		var failed bool
-		lo.Must0(domigraph.BFS(taskState.resourceStatesTree, util.ResourceID(taskState.name, taskState.namespace, taskState.groupVersionKind), func(id string) bool {
-			state := lo.Must(taskState.resourceStatesTree.Vertex(id))
-			state.RTransaction(func(s *ResourceState) {
-				if s.Status() == ResourceStatusFailed {
-					failed = true
-				}
-			})
-
-			if failed {
-				return true
-			}
-
-			return false
-		}))
-
-		return failed
-	})
-
 	switch failMode {
 	case IgnoreAndContinueDeployProcess:
+		// This mode must do nothing when tracking of the resource fails, so neither a
+		// resource marked as failed nor an exceeded error budget may fail the task.
 	case FailWholeDeployProcessImmediately, LegacyHopeUntilEndOfDeployProcess:
+		// A resource marked as failed reports a durable failure it cannot recover from on
+		// its own, so it fails the task regardless of the allowed failures count.
+		failureConditions = append(failureConditions, func(taskState *ReadinessTaskState) bool {
+			var failed bool
+			lo.Must0(domigraph.BFS(taskState.resourceStatesTree, util.ResourceID(taskState.name, taskState.namespace, taskState.groupVersionKind), func(id string) bool {
+				state := lo.Must(taskState.resourceStatesTree.Vertex(id))
+				state.RTransaction(func(s *ResourceState) {
+					if s.Status() == ResourceStatusFailed {
+						failed = true
+					}
+				})
+
+				if failed {
+					return true
+				}
+
+				return false
+			}))
+
+			return failed
+		})
+
 		failureConditions = append(failureConditions, func(taskState *ReadinessTaskState) bool {
 			var totalErrsCount int
 			lo.Must0(domigraph.BFS(taskState.resourceStatesTree, util.ResourceID(taskState.name, taskState.namespace, taskState.groupVersionKind), func(id string) bool {

--- a/pkg/tracker/deployment/export_test.go
+++ b/pkg/tracker/deployment/export_test.go
@@ -1,0 +1,11 @@
+package deployment
+
+import appsv1 "k8s.io/api/apps/v1"
+
+func (d *Tracker) TestOnlyInjectReplicaSetModified(rs *appsv1.ReplicaSet) {
+	d.replicaSetModified <- rs
+}
+
+func (d *Tracker) TestOnlyInjectReplicaSetDeleted(rs *appsv1.ReplicaSet) {
+	d.replicaSetDeleted <- rs
+}

--- a/pkg/tracker/deployment/export_test.go
+++ b/pkg/tracker/deployment/export_test.go
@@ -2,10 +2,26 @@ package deployment
 
 import appsv1 "k8s.io/api/apps/v1"
 
+func (d *Tracker) TestOnlyInjectReplicaSetAdded(rs *appsv1.ReplicaSet) {
+	d.replicaSetAdded <- rs
+}
+
 func (d *Tracker) TestOnlyInjectReplicaSetModified(rs *appsv1.ReplicaSet) {
 	d.replicaSetModified <- rs
 }
 
 func (d *Tracker) TestOnlyInjectReplicaSetDeleted(rs *appsv1.ReplicaSet) {
 	d.replicaSetDeleted <- rs
+}
+
+func (d *Tracker) TestOnlyInjectReplicaSetUnselected(rs *appsv1.ReplicaSet) {
+	d.replicaSetUnselected <- rs
+}
+
+func (d *Tracker) TestOnlyReplicaSetDeletedChanCap() int {
+	return cap(d.replicaSetDeleted)
+}
+
+func (d *Tracker) TestOnlyInjectResourceFailure(reason string) {
+	d.resourceFailed <- reason
 }

--- a/pkg/tracker/deployment/failure.go
+++ b/pkg/tracker/deployment/failure.go
@@ -1,0 +1,37 @@
+package deployment
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/werf/kubedog/pkg/tracker"
+)
+
+type resourceFailure struct {
+	reason            string
+	fromReplicaSetUID types.UID
+	mode              FailureMode
+}
+
+func (d *Tracker) handleResourceFailure(ctx context.Context, failure resourceFailure) error {
+	d.State = tracker.ResourceFailed
+	d.failedFromReplicaSetUID = failure.fromReplicaSetUID
+
+	status, err := d.newStatus(d.lastObject)
+	if err != nil {
+		return err
+	}
+
+	status.IsReady = false
+	status.IsFailed = true
+	status.FailedReason = failure.reason
+	status.FailureMode = failure.mode
+
+	select {
+	case d.Failed <- status:
+		return nil
+	case <-ctx.Done():
+		return context.Cause(ctx)
+	}
+}

--- a/pkg/tracker/deployment/harness_test.go
+++ b/pkg/tracker/deployment/harness_test.go
@@ -1,0 +1,326 @@
+package deployment_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/werf/kubedog/pkg/informer"
+	"github.com/werf/kubedog/pkg/tracker"
+	"github.com/werf/kubedog/pkg/tracker/deployment"
+)
+
+const (
+	testNamespace      = "default"
+	testDeploymentName = "demo"
+)
+
+var (
+	gvrDeployments = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "deployments"}
+	gvrReplicaSets = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
+
+	depUID = types.UID("dep-uid-1")
+
+	errTimeout   = errors.New("timeout")
+	errTrackDone = errors.New("Track() exited")
+)
+
+func ptrTo[T any](v T) *T { return &v }
+
+type observation struct {
+	Kind string
+	Data any
+}
+
+type harnessConfig struct {
+	dynamicSeed []runtime.Object
+}
+
+type harness struct {
+	ctx     context.Context
+	dynamic dynamic.Interface
+	tracker *deployment.Tracker
+
+	events  chan observation
+	backlog []observation
+
+	done       chan struct{}
+	wg         sync.WaitGroup
+	trackErrMu sync.Mutex
+	trackErr   error
+}
+
+func newHarness(t *testing.T, cfg harnessConfig) *harness {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	dynClient := dynamicfake.NewSimpleDynamicClient(k8sscheme.Scheme, cfg.dynamicSeed...)
+	kubeClient := k8sfake.NewSimpleClientset()
+
+	watchErrCh := make(chan error, 100)
+	factory := informer.NewConcurrentInformerFactory(ctx.Done(), watchErrCh, dynClient, informer.ConcurrentInformerFactoryOptions{})
+
+	trk := deployment.NewTracker(testDeploymentName, testNamespace, kubeClient, factory, tracker.Options{IgnoreLogs: true})
+
+	h := &harness{
+		ctx:     ctx,
+		dynamic: dynClient,
+		tracker: trk,
+		events:  make(chan observation, 4096),
+		done:    make(chan struct{}),
+	}
+
+	forwardChan(h, "Added", trk.Added)
+	forwardChan(h, "Ready", trk.Ready)
+	forwardChan(h, "Failed", trk.Failed)
+	forwardChan(h, "Status", trk.Status)
+	forwardChan(h, "EventMsg", trk.EventMsg)
+	forwardChan(h, "AddedReplicaSet", trk.AddedReplicaSet)
+	forwardChan(h, "AddedPod", trk.AddedPod)
+	forwardChan(h, "PodError", trk.PodError)
+	forwardChan(h, "WatchErr", watchErrCh)
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		for {
+			select {
+			case <-trk.PodLogChunk:
+			case <-h.ctx.Done():
+				return
+			}
+		}
+	}()
+
+	go func() {
+		defer close(h.done)
+		defer func() {
+			if r := recover(); r != nil {
+				h.setTrackErr(fmt.Errorf("panic in Track(): %v", r))
+			}
+		}()
+		h.setTrackErr(trk.Track(ctx))
+	}()
+
+	t.Cleanup(func() {
+		cancel()
+		select {
+		case <-h.done:
+		case <-time.After(10 * time.Second):
+			t.Error("Track() did not exit within 10s after cancel")
+		}
+
+		forwardersDone := make(chan struct{})
+		go func() {
+			h.wg.Wait()
+			close(forwardersDone)
+		}()
+		select {
+		case <-forwardersDone:
+		case <-time.After(5 * time.Second):
+			t.Error("forwarder goroutines did not exit within 5s after cancel")
+		}
+	})
+
+	return h
+}
+
+func forwardChan[T any](h *harness, kind string, ch <-chan T) {
+	h.wg.Add(1)
+	go func() {
+		defer h.wg.Done()
+		for {
+			select {
+			case v := <-ch:
+				select {
+				case h.events <- observation{kind, v}:
+				case <-h.ctx.Done():
+					return
+				}
+			case <-h.ctx.Done():
+				return
+			}
+		}
+	}()
+}
+
+func (h *harness) setTrackErr(err error) {
+	h.trackErrMu.Lock()
+	defer h.trackErrMu.Unlock()
+	if h.trackErr == nil {
+		h.trackErr = err
+	}
+}
+
+func (h *harness) getTrackErr() error {
+	h.trackErrMu.Lock()
+	defer h.trackErrMu.Unlock()
+	return h.trackErr
+}
+
+func (h *harness) waitFor(kind string, timeout time.Duration, pred func(observation) bool) (observation, error) {
+	for i, ev := range h.backlog {
+		if ev.Kind == kind && (pred == nil || pred(ev)) {
+			h.backlog = append(h.backlog[:i:i], h.backlog[i+1:]...)
+			return ev, nil
+		}
+	}
+
+	deadline := time.NewTimer(timeout)
+	defer deadline.Stop()
+	for {
+		select {
+		case ev := <-h.events:
+			if ev.Kind == kind && (pred == nil || pred(ev)) {
+				return ev, nil
+			}
+			h.backlog = append(h.backlog, ev)
+		case <-h.done:
+			return observation{}, fmt.Errorf("%w (err=%v) while waiting for kind=%s", errTrackDone, h.getTrackErr(), kind)
+		case <-deadline.C:
+			return observation{}, fmt.Errorf("%w after %s waiting for kind=%s", errTimeout, timeout, kind)
+		}
+	}
+}
+
+func (h *harness) waitForNone(kind string, quiet time.Duration, pred func(observation) bool) error {
+	ev, err := h.waitFor(kind, quiet, pred)
+	if err == nil {
+		return fmt.Errorf("expected no %s within %s, but got: %+v", kind, quiet, ev)
+	}
+	if errors.Is(err, errTimeout) {
+		return nil
+	}
+	return err
+}
+
+func mustToUnstructured(t *testing.T, obj runtime.Object) *unstructured.Unstructured {
+	t.Helper()
+	m, err := runtime.DefaultUnstructuredConverter.ToUnstructured(obj)
+	if err != nil {
+		t.Fatalf("to unstructured: %v", err)
+	}
+	return &unstructured.Unstructured{Object: m}
+}
+
+func (h *harness) createObject(t *testing.T, gvr schema.GroupVersionResource, obj runtime.Object) {
+	t.Helper()
+	if _, err := h.dynamic.Resource(gvr).Namespace(testNamespace).Create(h.ctx, mustToUnstructured(t, obj), metav1.CreateOptions{}); err != nil {
+		t.Fatalf("create %s: %v", gvr.Resource, err)
+	}
+}
+
+func (h *harness) updateReplicaSet(t *testing.T, rs *appsv1.ReplicaSet) {
+	t.Helper()
+	cur, err := h.dynamic.Resource(gvrReplicaSets).Namespace(testNamespace).Get(h.ctx, rs.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get current replicaset: %v", err)
+	}
+	rs.ResourceVersion = cur.GetResourceVersion()
+	if _, err := h.dynamic.Resource(gvrReplicaSets).Namespace(testNamespace).Update(h.ctx, mustToUnstructured(t, rs), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update replicaset: %v", err)
+	}
+}
+
+func (h *harness) updateDeployment(t *testing.T, dep *appsv1.Deployment) {
+	t.Helper()
+	cur, err := h.dynamic.Resource(gvrDeployments).Namespace(testNamespace).Get(h.ctx, dep.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get current deployment: %v", err)
+	}
+	dep.ResourceVersion = cur.GetResourceVersion()
+	if _, err := h.dynamic.Resource(gvrDeployments).Namespace(testNamespace).Update(h.ctx, mustToUnstructured(t, dep), metav1.UpdateOptions{}); err != nil {
+		t.Fatalf("update deployment: %v", err)
+	}
+}
+
+func (h *harness) deleteObject(t *testing.T, gvr schema.GroupVersionResource, name string) {
+	t.Helper()
+	if err := h.dynamic.Resource(gvr).Namespace(testNamespace).Delete(h.ctx, name, metav1.DeleteOptions{}); err != nil {
+		t.Fatalf("delete %s/%s: %v", gvr.Resource, name, err)
+	}
+}
+
+func baseSelector() *metav1.LabelSelector {
+	return &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}}
+}
+
+func basePodTemplate() corev1.PodTemplateSpec {
+	return corev1.PodTemplateSpec{
+		ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+		Spec: corev1.PodSpec{
+			Containers: []corev1.Container{{Name: "c", Image: "busybox:1"}},
+		},
+	}
+}
+
+func newNotReadyDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: testDeploymentName, Namespace: testNamespace, UID: depUID, Generation: 1},
+		Spec: appsv1.DeploymentSpec{
+			Replicas: ptrTo(int32(1)),
+			Selector: baseSelector(),
+			Template: basePodTemplate(),
+		},
+		Status: appsv1.DeploymentStatus{ObservedGeneration: 1},
+	}
+}
+
+func newReplicaSet(name string, uid types.UID) *appsv1.ReplicaSet {
+	return &appsv1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			UID:       uid,
+			Labels:    map[string]string{"app": "demo"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: testDeploymentName, UID: depUID, Controller: ptrTo(true),
+			}},
+			CreationTimestamp: metav1.Now(),
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Replicas: ptrTo(int32(1)),
+			Selector: baseSelector(),
+			Template: basePodTemplate(),
+		},
+	}
+}
+
+func withReplicaFailure(rs *appsv1.ReplicaSet, reason, marker string) *appsv1.ReplicaSet {
+	rs.Status.Conditions = []appsv1.ReplicaSetCondition{{
+		Type:               appsv1.ReplicaSetReplicaFailure,
+		Status:             corev1.ConditionTrue,
+		Reason:             reason,
+		Message:            fmt.Sprintf("pods %q is forbidden: exceeded quota: compute-quota [%s]", rs.Name, marker),
+		LastTransitionTime: metav1.Now(),
+	}}
+	return rs
+}
+
+func failedWithMarker(marker string) func(observation) bool {
+	return func(ev observation) bool {
+		status, ok := ev.Data.(deployment.DeploymentStatus)
+		if !ok {
+			return false
+		}
+		return status.IsFailed && strings.Contains(status.FailedReason, marker)
+	}
+}

--- a/pkg/tracker/deployment/harness_test.go
+++ b/pkg/tracker/deployment/harness_test.go
@@ -49,7 +49,8 @@ type observation struct {
 }
 
 type harnessConfig struct {
-	dynamicSeed []runtime.Object
+	dynamicSeed          []runtime.Object
+	prepareDynamicClient func(*dynamicfake.FakeDynamicClient)
 }
 
 type harness struct {
@@ -72,6 +73,9 @@ func newHarness(t *testing.T, cfg harnessConfig) *harness {
 	ctx, cancel := context.WithCancel(context.Background())
 
 	dynClient := dynamicfake.NewSimpleDynamicClient(k8sscheme.Scheme, cfg.dynamicSeed...)
+	if cfg.prepareDynamicClient != nil {
+		cfg.prepareDynamicClient(dynClient)
+	}
 	kubeClient := k8sfake.NewSimpleClientset()
 
 	watchErrCh := make(chan error, 100)
@@ -257,6 +261,19 @@ func (h *harness) deleteObject(t *testing.T, gvr schema.GroupVersionResource, na
 	}
 }
 
+// injectReplicaSetDeletedAndWait delivers a ReplicaSet deletion straight to the
+// tracker and returns only after the tracker has handled it. Deletions are
+// idempotent, so the barrier is built by overfilling the channel: for a capacity
+// of N, send N+1 returns once the tracker received the first deletion, and send
+// N+2 returns once it received the second one, which can only happen after the
+// first one was handled to completion.
+func (h *harness) injectReplicaSetDeletedAndWait(t *testing.T, rs *appsv1.ReplicaSet) {
+	t.Helper()
+	for i := 0; i < h.tracker.TestOnlyReplicaSetDeletedChanCap()+2; i++ {
+		h.tracker.TestOnlyInjectReplicaSetDeleted(rs.DeepCopy())
+	}
+}
+
 func baseSelector() *metav1.LabelSelector {
 	return &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}}
 }
@@ -281,6 +298,17 @@ func newNotReadyDeployment() *appsv1.Deployment {
 		},
 		Status: appsv1.DeploymentStatus{ObservedGeneration: 1},
 	}
+}
+
+func newReadyDeployment() *appsv1.Deployment {
+	dep := newNotReadyDeployment()
+	dep.Status = appsv1.DeploymentStatus{
+		ObservedGeneration: 1,
+		Replicas:           1,
+		UpdatedReplicas:    1,
+		AvailableReplicas:  1,
+	}
+	return dep
 }
 
 func newReplicaSet(name string, uid types.UID) *appsv1.ReplicaSet {
@@ -316,11 +344,15 @@ func withReplicaFailure(rs *appsv1.ReplicaSet, reason, marker string) *appsv1.Re
 }
 
 func failedWithMarker(marker string) func(observation) bool {
+	return failedWithMode(marker, deployment.FailureModeFatal)
+}
+
+func failedWithMode(marker string, mode deployment.FailureMode) func(observation) bool {
 	return func(ev observation) bool {
 		status, ok := ev.Data.(deployment.DeploymentStatus)
 		if !ok {
 			return false
 		}
-		return status.IsFailed && strings.Contains(status.FailedReason, marker)
+		return status.IsFailed && status.FailureMode == mode && strings.Contains(status.FailedReason, marker)
 	}
 }

--- a/pkg/tracker/deployment/replicaset_failure.go
+++ b/pkg/tracker/deployment/replicaset_failure.go
@@ -1,0 +1,164 @@
+package deployment
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/samber/lo"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
+
+	"github.com/werf/kubedog/pkg/tracker"
+	"github.com/werf/kubedog/pkg/utils"
+)
+
+func (d *Tracker) clearReplicaSetFailure(replicaSetUID types.UID) {
+	if replicaSetUID == "" || d.failedFromReplicaSetUID != replicaSetUID {
+		return
+	}
+
+	d.failedFromReplicaSetUID = ""
+
+	if d.State == tracker.ResourceFailed {
+		d.State = tracker.ResourceAdded
+	}
+}
+
+func (d *Tracker) rearmReplicaSetFailure(rs *appsv1.ReplicaSet) {
+	if _, failed := replicaSetFailure(rs); failed {
+		return
+	}
+
+	delete(d.reportedReplicaSetFailures, rs.UID)
+	d.clearReplicaSetFailure(rs.UID)
+}
+
+func (d *Tracker) isStaleReplicaSet(rs *appsv1.ReplicaSet) bool {
+	_, deleted := d.deletedReplicaSetUIDs[rs.UID]
+	return deleted
+}
+
+func (d *Tracker) handleNewReplicaSetFailure(ctx context.Context) error {
+	if d.lastObject == nil || !d.replicaSetsSynced {
+		return nil
+	}
+
+	newReplicaSet, err := utils.FindNewReplicaSet(d.lastObject, lo.Values(d.knownReplicaSets))
+	if err != nil {
+		return err
+	}
+	if newReplicaSet == nil {
+		return nil
+	}
+
+	failure, failed := replicaSetFailure(newReplicaSet)
+	if !failed {
+		return nil
+	}
+
+	if deploymentStatusReady(d.lastObject) {
+		delete(d.reportedReplicaSetFailures, newReplicaSet.UID)
+		d.clearReplicaSetFailure(newReplicaSet.UID)
+		return nil
+	}
+
+	mode := replicaSetFailureMode(failure.Message, d.deploymentCanReleaseQuota(newReplicaSet))
+	// ReplicaSet controllers retain FailedCreate until a successful retry. Keep
+	// the first classification until that condition clears so an old condition
+	// cannot become fatal merely because an older ReplicaSet finished scaling down.
+	if _, reported := d.reportedReplicaSetFailures[newReplicaSet.UID]; reported {
+		return nil
+	}
+	d.reportedReplicaSetFailures[newReplicaSet.UID] = struct{}{}
+
+	return d.handleResourceFailure(ctx, resourceFailure{
+		reason:            fmt.Sprintf("%s: %s", failure.Reason, failure.Message),
+		fromReplicaSetUID: newReplicaSet.UID,
+		mode:              mode,
+	})
+}
+
+func replicaSetFailureMode(message string, deploymentCanRecover bool) FailureMode {
+	message = strings.ToLower(message)
+	if strings.Contains(message, " is invalid:") ||
+		(strings.Contains(message, "exceeded quota:") && !deploymentCanRecover) {
+		return FailureModeFatal
+	}
+
+	return FailureModeCounted
+}
+
+func (d *Tracker) deploymentCanReleaseQuota(newReplicaSet *appsv1.ReplicaSet) bool {
+	oldReplicaSetsHaveDesiredReplicas := false
+	allDesiredReplicas := *newReplicaSet.Spec.Replicas
+	for _, rs := range d.knownReplicaSets {
+		if rs.UID == newReplicaSet.UID || !metav1.IsControlledBy(rs, d.lastObject) {
+			continue
+		}
+
+		desiredReplicas := *rs.Spec.Replicas
+		if rs.Status.TerminatingReplicas != nil && *rs.Status.TerminatingReplicas > 0 {
+			return true
+		}
+		if rs.Status.Replicas > desiredReplicas {
+			return true
+		}
+
+		allDesiredReplicas += desiredReplicas
+		oldReplicaSetsHaveDesiredReplicas = oldReplicaSetsHaveDesiredReplicas || desiredReplicas > 0
+	}
+	if !oldReplicaSetsHaveDesiredReplicas {
+		return false
+	}
+
+	if d.lastObject.Spec.Strategy.Type == appsv1.RecreateDeploymentStrategyType {
+		return true
+	}
+	if d.lastObject.Spec.Strategy.Type != appsv1.RollingUpdateDeploymentStrategyType ||
+		d.lastObject.Spec.Strategy.RollingUpdate == nil {
+		return false
+	}
+
+	desiredReplicas := *d.lastObject.Spec.Replicas
+	rollingUpdate := d.lastObject.Spec.Strategy.RollingUpdate
+	maxSurge, err := intstr.GetScaledValueFromIntOrPercent(
+		intstr.ValueOrDefault(rollingUpdate.MaxSurge, intstr.FromInt32(0)), int(desiredReplicas), true,
+	)
+	if err != nil {
+		return true
+	}
+	maxUnavailable, err := intstr.GetScaledValueFromIntOrPercent(
+		intstr.ValueOrDefault(rollingUpdate.MaxUnavailable, intstr.FromInt32(0)), int(desiredReplicas), false,
+	)
+	if err != nil {
+		return true
+	}
+	if maxSurge == 0 && maxUnavailable == 0 {
+		maxUnavailable = 1
+	}
+	if int32(maxUnavailable) > desiredReplicas {
+		maxUnavailable = int(desiredReplicas)
+	}
+
+	minimumAvailable := desiredReplicas - int32(maxUnavailable)
+	newUnavailable := *newReplicaSet.Spec.Replicas - newReplicaSet.Status.AvailableReplicas
+	return allDesiredReplicas-minimumAvailable-newUnavailable > 0
+}
+
+func replicaSetFailure(rs *appsv1.ReplicaSet) (appsv1.ReplicaSetCondition, bool) {
+	for _, condition := range rs.Status.Conditions {
+		if condition.Type != appsv1.ReplicaSetReplicaFailure ||
+			condition.Status != corev1.ConditionTrue ||
+			condition.Reason != replicaSetFailedCreateReason {
+			continue
+		}
+
+		return condition, true
+	}
+
+	return appsv1.ReplicaSetCondition{}, false
+}

--- a/pkg/tracker/deployment/replicaset_failure_test.go
+++ b/pkg/tracker/deployment/replicaset_failure_test.go
@@ -1,0 +1,52 @@
+package deployment
+
+import "testing"
+
+func TestReplicaSetFailureMode_whenFailedCreateMessageIsClassified(t *testing.T) {
+	tests := []struct {
+		name                 string
+		message              string
+		deploymentCanRecover bool
+		want                 FailureMode
+	}{
+		{
+			name:    "quota exhaustion is fatal",
+			message: `pods "demo-111" is forbidden: exceeded quota: compute-quota`,
+			want:    FailureModeFatal,
+		},
+		{
+			name:                 "quota exhaustion is counted when rollout can release quota",
+			message:              `pods "demo-111" is forbidden: exceeded quota: compute-quota`,
+			deploymentCanRecover: true,
+			want:                 FailureModeCounted,
+		},
+		{
+			name:    "invalid pod specification is fatal",
+			message: `Pod "demo-111" is invalid: spec.containers[0].resources.requests: Invalid value`,
+			want:    FailureModeFatal,
+		},
+		{
+			name:    "temporary API failure is counted",
+			message: "failed calling create: temporary apiserver connection refused",
+			want:    FailureModeCounted,
+		},
+		{
+			name:    "admission webhook rejection is counted",
+			message: `admission webhook "policy.example" denied the request`,
+			want:    FailureModeCounted,
+		},
+		{
+			name:    "RBAC rejection is counted",
+			message: `pods is forbidden: User "system:serviceaccount:default:controller" cannot create resource "pods"`,
+			want:    FailureModeCounted,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := replicaSetFailureMode(tt.message, tt.deploymentCanRecover); got != tt.want {
+				t.Fatalf("replicaSetFailureMode(%q, %t) = %v, want %v", tt.message, tt.deploymentCanRecover, got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/tracker/deployment/status.go
+++ b/pkg/tracker/deployment/status.go
@@ -9,6 +9,17 @@ import (
 	"github.com/werf/kubedog/pkg/tracker/pod"
 )
 
+// FailureMode qualifies a reported failure: a counted one may be transient and spends the
+// consumer's error budget, while a fatal one is durable and bypasses it.
+type FailureMode uint8
+
+const (
+	// FailureModeCounted is a recoverable failure charged against the consumer's error budget.
+	FailureModeCounted FailureMode = iota
+	// FailureModeFatal is a rollout-wide failure that cannot recover without an external change.
+	FailureModeFatal
+)
+
 type DeploymentStatus struct {
 	appsv1.DeploymentStatus
 
@@ -23,6 +34,7 @@ type DeploymentStatus struct {
 	IsReady      bool
 	IsFailed     bool
 	FailedReason string
+	FailureMode  FailureMode
 
 	Pods map[string]pod.PodStatus
 	// New Pod belongs to the new ReplicaSet of the Deployment,
@@ -78,17 +90,14 @@ processingPodsStatuses:
 			TargetValue: *object.Spec.Replicas,
 		}
 
-		res.IsReady = true
+		res.IsReady = deploymentStatusReady(object)
 		if object.Status.UpdatedReplicas != *object.Spec.Replicas {
-			res.IsReady = false
 			res.WaitingForMessages = append(res.WaitingForMessages, fmt.Sprintf("up-to-date %d->%d", object.Status.UpdatedReplicas, *object.Spec.Replicas))
 		}
 		if object.Status.Replicas != *object.Spec.Replicas {
-			res.IsReady = false
 			res.WaitingForMessages = append(res.WaitingForMessages, fmt.Sprintf("replicas %d->%d", object.Status.Replicas, *object.Spec.Replicas))
 		}
 		if object.Status.AvailableReplicas != *object.Spec.Replicas {
-			res.IsReady = false
 			res.WaitingForMessages = append(res.WaitingForMessages, fmt.Sprintf("available %d->%d", object.Status.AvailableReplicas, *object.Spec.Replicas))
 		}
 	} else {
@@ -101,4 +110,16 @@ processingPodsStatuses:
 	}
 
 	return res
+}
+
+// deploymentStatusReady reports whether the Deployment controller has observed the
+// current spec and reports every replica up-to-date, present and available.
+func deploymentStatusReady(object *appsv1.Deployment) bool {
+	if object.Status.ObservedGeneration < object.Generation || object.Spec.Replicas == nil {
+		return false
+	}
+
+	return object.Status.UpdatedReplicas == *object.Spec.Replicas &&
+		object.Status.Replicas == *object.Spec.Replicas &&
+		object.Status.AvailableReplicas == *object.Spec.Replicas
 }

--- a/pkg/tracker/deployment/tracker.go
+++ b/pkg/tracker/deployment/tracker.go
@@ -26,9 +26,8 @@ import (
 	"github.com/werf/kubedog/pkg/utils"
 )
 
-// replicaSetFailedCreateReason is the reason the ReplicaSet controller sets on
-// the ReplicaSetReplicaFailure condition when it cannot create pods, e.g.
-// because a namespace quota is exceeded.
+// replicaSetFailedCreateReason is set by the ReplicaSet controller on the
+// ReplicaSetReplicaFailure condition when it cannot create pods.
 const replicaSetFailedCreateReason = "FailedCreate"
 
 type ReplicaSetAddedReport struct {
@@ -54,9 +53,11 @@ type Tracker struct {
 	NewReplicaSetName string
 
 	knownReplicaSets           map[string]*appsv1.ReplicaSet
+	deletedReplicaSetUIDs      map[types.UID]struct{}
 	lastObject                 *appsv1.Deployment
-	failedReason               string
-	reportedReplicaSetFailures map[types.UID]string
+	failedFromReplicaSetUID    types.UID
+	reportedReplicaSetFailures map[types.UID]struct{}
+	replicaSetsSynced          bool
 	podStatuses                map[string]pod.PodStatus
 	rsNameByPod                map[string]string
 
@@ -77,14 +78,16 @@ type Tracker struct {
 	PodLogChunk     chan *replicaset.ReplicaSetPodLogChunk
 	PodError        chan PodErrorReport
 
-	resourceAdded      chan *appsv1.Deployment
-	resourceModified   chan *appsv1.Deployment
-	resourceDeleted    chan *appsv1.Deployment
-	resourceFailed     chan interface{}
-	replicaSetAdded    chan *appsv1.ReplicaSet
-	replicaSetModified chan *appsv1.ReplicaSet
-	replicaSetDeleted  chan *appsv1.ReplicaSet
-	errors             chan error
+	resourceAdded        chan *appsv1.Deployment
+	resourceModified     chan *appsv1.Deployment
+	resourceDeleted      chan *appsv1.Deployment
+	resourceFailed       chan interface{}
+	replicaSetAdded      chan *appsv1.ReplicaSet
+	replicaSetModified   chan *appsv1.ReplicaSet
+	replicaSetDeleted    chan *appsv1.ReplicaSet
+	replicaSetUnselected chan *appsv1.ReplicaSet
+	replicaSetSynced     chan struct{}
+	errors               chan error
 
 	podAddedRelay           chan *corev1.Pod
 	podStatusesRelay        chan map[string]pod.PodStatus
@@ -117,21 +120,27 @@ func NewTracker(name, namespace string, kube kubernetes.Interface, informerFacto
 		PodError:        make(chan PodErrorReport),
 
 		knownReplicaSets:           make(map[string]*appsv1.ReplicaSet),
-		reportedReplicaSetFailures: make(map[types.UID]string),
+		deletedReplicaSetUIDs:      make(map[types.UID]struct{}),
+		reportedReplicaSetFailures: make(map[types.UID]struct{}),
 		podStatuses:                make(map[string]pod.PodStatus),
 		rsNameByPod:                make(map[string]string),
 
 		ignoreLogs:                               opts.IgnoreLogs,
 		ignoreReadinessProbeFailsByContainerName: opts.IgnoreReadinessProbeFailsByContainerName,
 
-		errors:             make(chan error, 1),
-		resourceAdded:      make(chan *appsv1.Deployment, 1),
-		resourceModified:   make(chan *appsv1.Deployment, 1),
-		resourceDeleted:    make(chan *appsv1.Deployment, 1),
-		resourceFailed:     make(chan interface{}, 1),
-		replicaSetAdded:    make(chan *appsv1.ReplicaSet, 1),
-		replicaSetModified: make(chan *appsv1.ReplicaSet, 1),
-		replicaSetDeleted:  make(chan *appsv1.ReplicaSet, 1),
+		errors:           make(chan error, 1),
+		resourceAdded:    make(chan *appsv1.Deployment, 1),
+		resourceModified: make(chan *appsv1.Deployment, 1),
+		resourceDeleted:  make(chan *appsv1.Deployment, 1),
+		resourceFailed:   make(chan interface{}, 1),
+		// ReplicaSet events come from a single informer goroutine and fan out into three
+		// channels. Unbuffered sends keep them in order: a buffered Added could otherwise
+		// be consumed after a newer Modified and overwrite a fresh snapshot with a stale one.
+		replicaSetAdded:      make(chan *appsv1.ReplicaSet),
+		replicaSetModified:   make(chan *appsv1.ReplicaSet),
+		replicaSetDeleted:    make(chan *appsv1.ReplicaSet),
+		replicaSetUnselected: make(chan *appsv1.ReplicaSet),
+		replicaSetSynced:     make(chan struct{}),
 
 		podAddedRelay:           make(chan *corev1.Pod, 1),
 		podStatusesRelay:        make(chan map[string]pod.PodStatus, 10),
@@ -163,7 +172,7 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 				return err
 			}
 			defer cleanupFn()
-			if err := d.handleNewReplicaSetFailure(); err != nil {
+			if err := d.handleNewReplicaSetFailure(ctx); err != nil {
 				return err
 			}
 		case object := <-d.resourceModified:
@@ -172,14 +181,16 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 				return err
 			}
 			defer cleanupFn()
-			if err := d.handleNewReplicaSetFailure(); err != nil {
+			if err := d.handleNewReplicaSetFailure(ctx); err != nil {
 				return err
 			}
 		case <-d.resourceDeleted:
 			d.State = tracker.ResourceDeleted
 			d.lastObject = nil
 			d.knownReplicaSets = make(map[string]*appsv1.ReplicaSet)
-			d.reportedReplicaSetFailures = make(map[types.UID]string)
+			d.deletedReplicaSetUIDs = make(map[types.UID]struct{})
+			d.reportedReplicaSetFailures = make(map[types.UID]struct{})
+			d.failedFromReplicaSetUID = ""
 			d.podStatuses = make(map[string]pod.PodStatus)
 			d.rsNameByPod = make(map[string]string)
 			d.TrackedPodsNames = nil
@@ -188,15 +199,13 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 		case failure := <-d.resourceFailed:
 			switch failure := failure.(type) {
 			case string:
-				// Failures are reported by the events informer, which is
-				// stopped only when Track returns. With no live object there is
-				// no status to report the failure on, and the failure itself
-				// belongs to an already deleted object.
+				// The events informer outlives the object: with no live object
+				// there is no status to report the failure on.
 				if d.lastObject == nil {
 					break
 				}
 
-				if err := d.handleResourceFailure(failure); err != nil {
+				if err := d.handleResourceFailure(ctx, resourceFailure{reason: failure, mode: FailureModeCounted}); err != nil {
 					return err
 				}
 			default:
@@ -204,7 +213,12 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 			}
 
 		case rs := <-d.replicaSetAdded:
+			if d.isStaleReplicaSet(rs) {
+				break
+			}
+
 			d.knownReplicaSets[rs.Name] = rs
+			d.rearmReplicaSetFailure(rs)
 
 			if d.lastObject != nil {
 				rsNew, err := utils.IsReplicaSetNew(d.lastObject, d.knownReplicaSets, rs.Name)
@@ -212,12 +226,10 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 					return err
 				}
 
-				d.StatusGeneration++
-				newPodsNames, err := d.getNewPodsNames()
+				status, err := d.newStatus(d.lastObject)
 				if err != nil {
 					return err
 				}
-				status := NewDeploymentStatus(d.lastObject, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
 
 				d.AddedReplicaSet <- ReplicaSetAddedReport{
 					ReplicaSet: replicaset.ReplicaSet{
@@ -227,44 +239,72 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 					DeploymentStatus: status,
 				}
 
-				if err := d.handleNewReplicaSetFailure(); err != nil {
+				if err := d.handleNewReplicaSetFailure(ctx); err != nil {
 					return err
 				}
 			}
 
 		case rs := <-d.replicaSetModified:
-			// Additions, modifications and deletions are delivered over
-			// separate channels, so a modification of an already replaced
-			// ReplicaSet may be observed after addition of its same-named
-			// successor: applying it would resurrect the dead incarnation.
+			if d.isStaleReplicaSet(rs) {
+				break
+			}
+
+			// A same-named successor may already be known: applying an older
+			// incarnation would resurrect the dead one.
 			if known, found := d.knownReplicaSets[rs.Name]; !found || known.UID == rs.UID {
 				d.knownReplicaSets[rs.Name] = rs
+				d.rearmReplicaSetFailure(rs)
 
 				if d.lastObject != nil {
-					if err := d.handleNewReplicaSetFailure(); err != nil {
+					if err := d.handleNewReplicaSetFailure(ctx); err != nil {
 						return err
 					}
 				}
 			}
 
 		case rs := <-d.replicaSetDeleted:
-			// Same reordering hazard as for modifications: dropping the
-			// ReplicaSet by name alone would lose the live successor.
+			d.deletedReplicaSetUIDs[rs.UID] = struct{}{}
+
+			// Dropping the ReplicaSet by name alone would lose a live successor.
 			if known, found := d.knownReplicaSets[rs.Name]; found && known.UID == rs.UID {
 				delete(d.knownReplicaSets, rs.Name)
 			}
 			delete(d.reportedReplicaSetFailures, rs.UID)
+
+			d.clearReplicaSetFailure(rs.UID)
+
+			// Deletion may promote an already failing ReplicaSet to the new one:
+			// its failure was suppressed before and nothing else would report it.
+			if d.lastObject != nil {
+				if err := d.handleNewReplicaSetFailure(ctx); err != nil {
+					return err
+				}
+			}
+
+		case rs := <-d.replicaSetUnselected:
+			if known, found := d.knownReplicaSets[rs.Name]; found && known.UID == rs.UID {
+				delete(d.knownReplicaSets, rs.Name)
+			}
+			delete(d.reportedReplicaSetFailures, rs.UID)
+			d.clearReplicaSetFailure(rs.UID)
+
+			if d.lastObject != nil {
+				if err := d.handleNewReplicaSetFailure(ctx); err != nil {
+					return err
+				}
+			}
+
+		case <-d.replicaSetSynced:
+			d.replicaSetsSynced = true
+			if err := d.handleNewReplicaSetFailure(ctx); err != nil {
+				return err
+			}
 
 		case pod := <-d.podAddedRelay:
 			rsName := utils.GetPodReplicaSetName(pod)
 			d.rsNameByPod[pod.Name] = rsName
 
 			if d.lastObject != nil {
-				d.StatusGeneration++
-				newPodsNames, err := d.getNewPodsNames()
-				if err != nil {
-					return err
-				}
 				rsNew, err := utils.IsReplicaSetNew(d.lastObject, d.knownReplicaSets, rsName)
 				if err != nil {
 					return err
@@ -272,7 +312,11 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 				if len(d.knownReplicaSets) == 0 {
 					rsNew = true
 				}
-				status := NewDeploymentStatus(d.lastObject, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
+
+				status, err := d.newStatus(d.lastObject)
+				if err != nil {
+					return err
+				}
 
 				d.AddedPod <- PodAddedReport{
 					ReplicaSetPod: replicaset.ReplicaSetPod{
@@ -366,12 +410,10 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 				d.podStatuses[podName] = containerError.PodStatus
 			}
 			if d.lastObject != nil {
-				d.StatusGeneration++
-				newPodsNames, err := d.getNewPodsNames()
+				status, err := d.newStatus(d.lastObject)
 				if err != nil {
 					return err
 				}
-				status := NewDeploymentStatus(d.lastObject, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
 
 				for podName, containerError := range podContainerErrors {
 					rsName, hasKey := d.rsNameByPod[podName]
@@ -522,6 +564,8 @@ func (d *Tracker) runDeploymentInformer(ctx context.Context) (cleanupFn func(), 
 func (d *Tracker) runReplicaSetsInformer(ctx context.Context, object *appsv1.Deployment) (cleanupFn func(), err error) {
 	rsInformer := replicaset.NewReplicaSetInformer(&d.Tracker, utils.ControllerAccessor(object))
 	rsInformer.WithChannels(d.replicaSetAdded, d.replicaSetModified, d.replicaSetDeleted, d.errors)
+	rsInformer.WithUnselectedChannel(d.replicaSetUnselected)
+	rsInformer.WithSyncedChannel(d.replicaSetSynced)
 	return rsInformer.Run(ctx)
 }
 
@@ -604,13 +648,11 @@ func (d *Tracker) runPodTracker(_ctx context.Context, podName, rsName string) er
 
 func (d *Tracker) handleDeploymentState(ctx context.Context, object *appsv1.Deployment) (cleanupFn func(), err error) {
 	d.lastObject = object
-	d.StatusGeneration++
 
-	newPodsNames, err := d.getNewPodsNames()
+	status, err := d.newStatus(object)
 	if err != nil {
 		return nil, err
 	}
-	status := NewDeploymentStatus(object, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
 
 	cleanupFn = func() {}
 
@@ -626,6 +668,9 @@ func (d *Tracker) handleDeploymentState(ctx context.Context, object *appsv1.Depl
 
 		podsInformerCleanupFn, err := d.runPodsInformer(ctx, object)
 		if err != nil {
+			// An informer left running has no consumer: its callbacks park forever
+			// on the unbuffered channels of a tracker that never starts.
+			replicasetsInformerCleanupFn()
 			return nil, fmt.Errorf("run pods informer: %w", err)
 		}
 
@@ -633,6 +678,8 @@ func (d *Tracker) handleDeploymentState(ctx context.Context, object *appsv1.Depl
 		if os.Getenv("KUBEDOG_DISABLE_EVENTS") != "1" {
 			eventsInformerCleanupFn, err = d.runEventsInformer(ctx, object)
 			if err != nil {
+				replicasetsInformerCleanupFn()
+				podsInformerCleanupFn()
 				return nil, fmt.Errorf("run events informer: %w", err)
 			}
 		}
@@ -691,73 +738,15 @@ func (d *Tracker) runEventsInformer(ctx context.Context, resource interface{}) (
 	return eventInformer.Run(ctx)
 }
 
-func (d *Tracker) handleResourceFailure(reason string) error {
-	d.State = tracker.ResourceFailed
-	d.failedReason = reason
-
+// newStatus deliberately leaves the sticky tracker failure out: a failure is reported
+// once by handleResourceFailure, and restamping it into every update reports it again.
+func (d *Tracker) newStatus(object *appsv1.Deployment) (DeploymentStatus, error) {
 	d.StatusGeneration++
+
 	newPodsNames, err := d.getNewPodsNames()
 	if err != nil {
-		return err
-	}
-	d.Failed <- NewDeploymentStatus(d.lastObject, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
-
-	return nil
-}
-
-// handleNewReplicaSetFailure fails the tracking as soon as the ReplicaSet the
-// Deployment is currently rolling out cannot create its pods.
-//
-// ReplicaSets of previous rollouts are skipped: their failures must not fail the
-// current rollout. A failure is reported once per ReplicaSet incarnation and
-// reason and is rearmed once the ReplicaSet controller clears the condition, so
-// a ReplicaSet that recovered and then failed again is reported anew.
-func (d *Tracker) handleNewReplicaSetFailure() error {
-	if d.lastObject == nil {
-		return nil
+		return DeploymentStatus{}, err
 	}
 
-	newReplicaSet, err := utils.FindNewReplicaSet(d.lastObject, lo.Values(d.knownReplicaSets))
-	if err != nil {
-		return err
-	}
-	if newReplicaSet == nil {
-		return nil
-	}
-
-	failure, failed := replicaSetFailure(newReplicaSet)
-	if !failed {
-		delete(d.reportedReplicaSetFailures, newReplicaSet.UID)
-		return nil
-	}
-
-	// The message carries volatile details, e.g. the quota usage at the moment the
-	// pod was rejected, so only the reason takes part in the deduplication.
-	if d.reportedReplicaSetFailures[newReplicaSet.UID] == failure.Reason {
-		return nil
-	}
-	d.reportedReplicaSetFailures[newReplicaSet.UID] = failure.Reason
-
-	return d.handleResourceFailure(fmt.Sprintf("%s: %s", failure.Reason, failure.Message))
-}
-
-// replicaSetFailure returns the condition set by the ReplicaSet controller when it
-// failed to create pods for the ReplicaSet.
-//
-// Unlike a Warning event, the ReplicaSetReplicaFailure condition is durable state:
-// the controller sets it while pod creation keeps failing and removes it as soon as
-// creation succeeds, so no event baseline is needed. FailedDelete is not fatal for a
-// rollout and is ignored here, just like the events informer ignores it.
-func replicaSetFailure(rs *appsv1.ReplicaSet) (appsv1.ReplicaSetCondition, bool) {
-	for _, condition := range rs.Status.Conditions {
-		if condition.Type != appsv1.ReplicaSetReplicaFailure ||
-			condition.Status != corev1.ConditionTrue ||
-			condition.Reason != replicaSetFailedCreateReason {
-			continue
-		}
-
-		return condition, true
-	}
-
-	return appsv1.ReplicaSetCondition{}, false
+	return NewDeploymentStatus(object, d.StatusGeneration, false, "", d.podStatuses, newPodsNames), nil
 }

--- a/pkg/tracker/deployment/tracker.go
+++ b/pkg/tracker/deployment/tracker.go
@@ -12,6 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/cache"
 
@@ -24,6 +25,11 @@ import (
 	"github.com/werf/kubedog/pkg/tracker/replicaset"
 	"github.com/werf/kubedog/pkg/utils"
 )
+
+// replicaSetFailedCreateReason is the reason the ReplicaSet controller sets on
+// the ReplicaSetReplicaFailure condition when it cannot create pods, e.g.
+// because a namespace quota is exceeded.
+const replicaSetFailedCreateReason = "FailedCreate"
 
 type ReplicaSetAddedReport struct {
 	ReplicaSet       replicaset.ReplicaSet
@@ -47,11 +53,12 @@ type Tracker struct {
 	Conditions        []string
 	NewReplicaSetName string
 
-	knownReplicaSets map[string]*appsv1.ReplicaSet
-	lastObject       *appsv1.Deployment
-	failedReason     string
-	podStatuses      map[string]pod.PodStatus
-	rsNameByPod      map[string]string
+	knownReplicaSets           map[string]*appsv1.ReplicaSet
+	lastObject                 *appsv1.Deployment
+	failedReason               string
+	reportedReplicaSetFailures map[types.UID]string
+	podStatuses                map[string]pod.PodStatus
+	rsNameByPod                map[string]string
 
 	ignoreLogs                               bool
 	ignoreReadinessProbeFailsByContainerName map[string]time.Duration
@@ -109,9 +116,10 @@ func NewTracker(name, namespace string, kube kubernetes.Interface, informerFacto
 		PodLogChunk:     make(chan *replicaset.ReplicaSetPodLogChunk, 1000),
 		PodError:        make(chan PodErrorReport),
 
-		knownReplicaSets: make(map[string]*appsv1.ReplicaSet),
-		podStatuses:      make(map[string]pod.PodStatus),
-		rsNameByPod:      make(map[string]string),
+		knownReplicaSets:           make(map[string]*appsv1.ReplicaSet),
+		reportedReplicaSetFailures: make(map[types.UID]string),
+		podStatuses:                make(map[string]pod.PodStatus),
+		rsNameByPod:                make(map[string]string),
 
 		ignoreLogs:                               opts.IgnoreLogs,
 		ignoreReadinessProbeFailsByContainerName: opts.IgnoreReadinessProbeFailsByContainerName,
@@ -155,16 +163,23 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 				return err
 			}
 			defer cleanupFn()
+			if err := d.handleNewReplicaSetFailure(); err != nil {
+				return err
+			}
 		case object := <-d.resourceModified:
 			cleanupFn, err := d.handleDeploymentState(ctx, object)
 			if err != nil {
 				return err
 			}
 			defer cleanupFn()
+			if err := d.handleNewReplicaSetFailure(); err != nil {
+				return err
+			}
 		case <-d.resourceDeleted:
 			d.State = tracker.ResourceDeleted
 			d.lastObject = nil
 			d.knownReplicaSets = make(map[string]*appsv1.ReplicaSet)
+			d.reportedReplicaSetFailures = make(map[types.UID]string)
 			d.podStatuses = make(map[string]pod.PodStatus)
 			d.rsNameByPod = make(map[string]string)
 			d.TrackedPodsNames = nil
@@ -173,21 +188,17 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 		case failure := <-d.resourceFailed:
 			switch failure := failure.(type) {
 			case string:
-				d.State = tracker.ResourceFailed
-				d.failedReason = failure
-
-				var status DeploymentStatus
-				if d.lastObject != nil {
-					d.StatusGeneration++
-					newPodsNames, err := d.getNewPodsNames()
-					if err != nil {
-						return err
-					}
-					status = NewDeploymentStatus(d.lastObject, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
-				} else {
-					status = DeploymentStatus{IsFailed: true, FailedReason: failure}
+				// Failures are reported by the events informer, which is
+				// stopped only when Track returns. With no live object there is
+				// no status to report the failure on, and the failure itself
+				// belongs to an already deleted object.
+				if d.lastObject == nil {
+					break
 				}
-				d.Failed <- status
+
+				if err := d.handleResourceFailure(failure); err != nil {
+					return err
+				}
 			default:
 				panic(fmt.Errorf("unexpected type %T", failure))
 			}
@@ -199,9 +210,6 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 				rsNew, err := utils.IsReplicaSetNew(d.lastObject, d.knownReplicaSets, rs.Name)
 				if err != nil {
 					return err
-				}
-				if len(d.knownReplicaSets) == 0 {
-					rsNew = true
 				}
 
 				d.StatusGeneration++
@@ -218,13 +226,34 @@ func (d *Tracker) Track(ctx context.Context) (err error) {
 					},
 					DeploymentStatus: status,
 				}
+
+				if err := d.handleNewReplicaSetFailure(); err != nil {
+					return err
+				}
 			}
 
 		case rs := <-d.replicaSetModified:
-			d.knownReplicaSets[rs.Name] = rs
+			// Additions, modifications and deletions are delivered over
+			// separate channels, so a modification of an already replaced
+			// ReplicaSet may be observed after addition of its same-named
+			// successor: applying it would resurrect the dead incarnation.
+			if known, found := d.knownReplicaSets[rs.Name]; !found || known.UID == rs.UID {
+				d.knownReplicaSets[rs.Name] = rs
+
+				if d.lastObject != nil {
+					if err := d.handleNewReplicaSetFailure(); err != nil {
+						return err
+					}
+				}
+			}
 
 		case rs := <-d.replicaSetDeleted:
-			delete(d.knownReplicaSets, rs.Name)
+			// Same reordering hazard as for modifications: dropping the
+			// ReplicaSet by name alone would lose the live successor.
+			if known, found := d.knownReplicaSets[rs.Name]; found && known.UID == rs.UID {
+				delete(d.knownReplicaSets, rs.Name)
+			}
+			delete(d.reportedReplicaSetFailures, rs.UID)
 
 		case pod := <-d.podAddedRelay:
 			rsName := utils.GetPodReplicaSetName(pod)
@@ -660,4 +689,75 @@ func (d *Tracker) runEventsInformer(ctx context.Context, resource interface{}) (
 	eventInformer := event.NewEventInformer(&d.Tracker, resource)
 	eventInformer.WithChannels(d.EventMsg, d.resourceFailed, d.errors)
 	return eventInformer.Run(ctx)
+}
+
+func (d *Tracker) handleResourceFailure(reason string) error {
+	d.State = tracker.ResourceFailed
+	d.failedReason = reason
+
+	d.StatusGeneration++
+	newPodsNames, err := d.getNewPodsNames()
+	if err != nil {
+		return err
+	}
+	d.Failed <- NewDeploymentStatus(d.lastObject, d.StatusGeneration, d.State == tracker.ResourceFailed, d.failedReason, d.podStatuses, newPodsNames)
+
+	return nil
+}
+
+// handleNewReplicaSetFailure fails the tracking as soon as the ReplicaSet the
+// Deployment is currently rolling out cannot create its pods.
+//
+// ReplicaSets of previous rollouts are skipped: their failures must not fail the
+// current rollout. A failure is reported once per ReplicaSet incarnation and
+// reason and is rearmed once the ReplicaSet controller clears the condition, so
+// a ReplicaSet that recovered and then failed again is reported anew.
+func (d *Tracker) handleNewReplicaSetFailure() error {
+	if d.lastObject == nil {
+		return nil
+	}
+
+	newReplicaSet, err := utils.FindNewReplicaSet(d.lastObject, lo.Values(d.knownReplicaSets))
+	if err != nil {
+		return err
+	}
+	if newReplicaSet == nil {
+		return nil
+	}
+
+	failure, failed := replicaSetFailure(newReplicaSet)
+	if !failed {
+		delete(d.reportedReplicaSetFailures, newReplicaSet.UID)
+		return nil
+	}
+
+	// The message carries volatile details, e.g. the quota usage at the moment the
+	// pod was rejected, so only the reason takes part in the deduplication.
+	if d.reportedReplicaSetFailures[newReplicaSet.UID] == failure.Reason {
+		return nil
+	}
+	d.reportedReplicaSetFailures[newReplicaSet.UID] = failure.Reason
+
+	return d.handleResourceFailure(fmt.Sprintf("%s: %s", failure.Reason, failure.Message))
+}
+
+// replicaSetFailure returns the condition set by the ReplicaSet controller when it
+// failed to create pods for the ReplicaSet.
+//
+// Unlike a Warning event, the ReplicaSetReplicaFailure condition is durable state:
+// the controller sets it while pod creation keeps failing and removes it as soon as
+// creation succeeds, so no event baseline is needed. FailedDelete is not fatal for a
+// rollout and is ignored here, just like the events informer ignores it.
+func replicaSetFailure(rs *appsv1.ReplicaSet) (appsv1.ReplicaSetCondition, bool) {
+	for _, condition := range rs.Status.Conditions {
+		if condition.Type != appsv1.ReplicaSetReplicaFailure ||
+			condition.Status != corev1.ConditionTrue ||
+			condition.Reason != replicaSetFailedCreateReason {
+			continue
+		}
+
+		return condition, true
+	}
+
+	return appsv1.ReplicaSetCondition{}, false
 }

--- a/pkg/tracker/deployment/tracker_failure_test.go
+++ b/pkg/tracker/deployment/tracker_failure_test.go
@@ -1,0 +1,49 @@
+package deployment
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/werf/kubedog/pkg/tracker/pod"
+)
+
+func TestHandleResourceFailure_whenContextCanceledWithoutReceiver(t *testing.T) {
+	ctx, cancel := context.WithCancelCause(context.Background())
+	expectedErr := errors.New("test cancellation")
+
+	trk := &Tracker{
+		lastObject:       &appsv1.Deployment{},
+		knownReplicaSets: make(map[string]*appsv1.ReplicaSet),
+		podStatuses:      make(map[string]pod.PodStatus),
+		rsNameByPod:      make(map[string]string),
+		Failed:           make(chan DeploymentStatus),
+	}
+
+	started := make(chan struct{})
+	done := make(chan error, 1)
+	go func() {
+		close(started)
+		done <- trk.handleResourceFailure(ctx, resourceFailure{
+			reason:            "failure",
+			fromReplicaSetUID: types.UID("rs-uid-1"),
+			mode:              FailureModeCounted,
+		})
+	}()
+
+	<-started
+	cancel(expectedErr)
+
+	select {
+	case err := <-done:
+		if !errors.Is(err, expectedErr) {
+			t.Fatalf("handleResourceFailure() error = %v, want %v", err, expectedErr)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("handleResourceFailure() remained blocked after context cancellation")
+	}
+}

--- a/pkg/tracker/deployment/tracker_quota_recovery_test.go
+++ b/pkg/tracker/deployment/tracker_quota_recovery_test.go
@@ -1,0 +1,144 @@
+package deployment_test
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/werf/kubedog/pkg/tracker/deployment"
+)
+
+func TestTrack_RecoversFromQuotaFailureWhenOldReplicaSetCanScaleDown(t *testing.T) {
+	deploymentObject := rollingDeployment(1, 1)
+	h := newHarness(t, harnessConfig{dynamicSeed: []runtime.Object{deploymentObject}})
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	oldReplicaSet := scalableOldReplicaSet()
+	h.createObject(t, gvrReplicaSets, oldReplicaSet)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for old AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-quota-recoverable-by-scale-down"
+	newReplicaSet := withReplicaFailure(newReplicaSet("demo-new", "rs-uid-new"), "FailedCreate", marker)
+	h.createObject(t, gvrReplicaSets, newReplicaSet)
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMode(marker, deployment.FailureModeCounted)); err != nil {
+		t.Fatalf("quota failure must remain recoverable while an old ReplicaSet can scale down: %v", err)
+	}
+}
+
+func TestTrack_RecoversFromQuotaFailureWhileOldReplicaSetPodsAreTerminating(t *testing.T) {
+	deploymentObject := rollingDeployment(0, 1)
+	h := newHarness(t, harnessConfig{dynamicSeed: []runtime.Object{deploymentObject}})
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	oldReplicaSet := scalableOldReplicaSet()
+	*oldReplicaSet.Spec.Replicas = 0
+	oldReplicaSet.Status.Replicas = 0
+	oldReplicaSet.Status.AvailableReplicas = 0
+	oldReplicaSet.Status.TerminatingReplicas = ptrTo(int32(1))
+	h.createObject(t, gvrReplicaSets, oldReplicaSet)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for terminating old AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-quota-recoverable-by-termination"
+	newReplicaSet := withReplicaFailure(newReplicaSet("demo-new", "rs-uid-new"), "FailedCreate", marker)
+	h.createObject(t, gvrReplicaSets, newReplicaSet)
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMode(marker, deployment.FailureModeCounted)); err != nil {
+		t.Fatalf("quota failure must remain recoverable while old Pods terminate: %v", err)
+	}
+}
+
+func TestTrack_ClassifiesInitialQuotaFailureAfterAllReplicaSetsAreObserved(t *testing.T) {
+	deploymentObject := rollingDeployment(1, 1)
+	oldReplicaSet := scalableOldReplicaSet()
+	const marker = "marker-quota-initial-snapshot"
+	newReplicaSet := withReplicaFailure(newReplicaSet("demo-new", "rs-uid-new"), "FailedCreate", marker)
+
+	h := newHarness(t, harnessConfig{
+		dynamicSeed:          []runtime.Object{deploymentObject},
+		prepareDynamicClient: initialReplicaSetListReactor(t, newReplicaSet, oldReplicaSet),
+	})
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMode(marker, deployment.FailureModeCounted)); err != nil {
+		t.Fatalf("initial failure must use the complete ReplicaSet snapshot: %v", err)
+	}
+}
+
+func TestTrack_DoesNotEscalateStaleQuotaFailureAfterOldReplicaSetScalesDown(t *testing.T) {
+	deploymentObject := rollingDeployment(1, 1)
+	h := newHarness(t, harnessConfig{dynamicSeed: []runtime.Object{deploymentObject}})
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	oldReplicaSet := scalableOldReplicaSet()
+	h.createObject(t, gvrReplicaSets, oldReplicaSet)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for old AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-quota-stale-after-scale-down"
+	newReplicaSet := withReplicaFailure(newReplicaSet("demo-new", "rs-uid-new"), "FailedCreate", marker)
+	h.createObject(t, gvrReplicaSets, newReplicaSet)
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMode(marker, deployment.FailureModeCounted)); err != nil {
+		t.Fatalf("wait for initial counted failure: %v", err)
+	}
+
+	scaledDown := oldReplicaSet.DeepCopy()
+	*scaledDown.Spec.Replicas = 0
+	scaledDown.Status.Replicas = 0
+	scaledDown.Status.AvailableReplicas = 0
+	h.updateReplicaSet(t, scaledDown)
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMode(marker, deployment.FailureModeFatal)); err != nil {
+		t.Fatalf("stale quota condition must not become fatal while the ReplicaSet controller retries: %v", err)
+	}
+}
+
+func rollingDeployment(maxUnavailable, maxSurge int32) *appsv1.Deployment {
+	deploymentObject := newNotReadyDeployment()
+	unavailable := intstr.FromInt32(maxUnavailable)
+	surge := intstr.FromInt32(maxSurge)
+	deploymentObject.Spec.Strategy = appsv1.DeploymentStrategy{
+		Type: appsv1.RollingUpdateDeploymentStrategyType,
+		RollingUpdate: &appsv1.RollingUpdateDeployment{
+			MaxUnavailable: &unavailable,
+			MaxSurge:       &surge,
+		},
+	}
+	return deploymentObject
+}
+
+func scalableOldReplicaSet() *appsv1.ReplicaSet {
+	oldReplicaSet := newReplicaSet("demo-old", "rs-uid-old")
+	oldReplicaSet.Spec.Template.Spec.Containers[0].Image = "busybox:old"
+	oldReplicaSet.Status.Replicas = 1
+	oldReplicaSet.Status.AvailableReplicas = 1
+	return oldReplicaSet
+}
+
+func initialReplicaSetListReactor(t *testing.T, replicaSets ...*appsv1.ReplicaSet) func(*dynamicfake.FakeDynamicClient) {
+	t.Helper()
+
+	return func(client *dynamicfake.FakeDynamicClient) {
+		client.PrependReactor("list", "replicasets", func(k8stesting.Action) (bool, runtime.Object, error) {
+			list := &unstructured.UnstructuredList{}
+			list.SetGroupVersionKind(schema.GroupVersionKind{Group: "apps", Version: "v1", Kind: "ReplicaSetList"})
+			for _, replicaSet := range replicaSets {
+				list.Items = append(list.Items, *mustToUnstructured(t, replicaSet))
+			}
+			return true, list, nil
+		})
+	}
+}

--- a/pkg/tracker/deployment/tracker_replicaset_recovery_test.go
+++ b/pkg/tracker/deployment/tracker_replicaset_recovery_test.go
@@ -1,0 +1,85 @@
+package deployment_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/werf/kubedog/pkg/tracker/deployment"
+)
+
+func TestTrack_RecoversFromTransientReplicaFailure(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-transient-apiserver-failure"
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	failed := withReplicaFailure(rs.DeepCopy(), "FailedCreate", marker)
+	failed.Status.Conditions[0].Message = "temporary apiserver connection refused [" + marker + "]"
+	h.createObject(t, gvrReplicaSets, failed)
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMode(marker, deployment.FailureModeCounted)); err != nil {
+		t.Fatalf("wait for counted failure: %v", err)
+	}
+
+	h.updateReplicaSet(t, rs.DeepCopy())
+	h.updateDeployment(t, newReadyDeployment())
+	if _, err := h.waitFor("Ready", 10*time.Second, nil); err != nil {
+		t.Fatalf("transient failure must allow later readiness: %v", err)
+	}
+}
+
+func TestTrack_DetectsFailureAfterSameNameReplicaSetReplacementUpdate(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	oldReplicaSet := newReplicaSet("demo-111", "rs-uid-old")
+	h.createObject(t, gvrReplicaSets, oldReplicaSet)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(oldReplicaSet.Name)); err != nil {
+		t.Fatalf("wait for old AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-replacement-update"
+	replacement := withReplicaFailure(oldReplicaSet.DeepCopy(), "FailedCreate", marker)
+	replacement.UID = types.UID("rs-uid-new")
+	h.updateReplicaSet(t, replacement)
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("same-name replacement delivered as Update must be tracked: %v", err)
+	}
+}
+
+func TestTrack_ReportsReplicaFailureAfterSelectorReentry(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-selector-reentry"
+	rs := withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker)
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for initial failure: %v", err)
+	}
+
+	h.tracker.TestOnlyInjectReplicaSetUnselected(rs.DeepCopy())
+	h.tracker.TestOnlyInjectReplicaSetAdded(rs.DeepCopy())
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("same UID must become reportable after selector reentry: %v", err)
+	}
+}

--- a/pkg/tracker/deployment/tracker_replicaset_test.go
+++ b/pkg/tracker/deployment/tracker_replicaset_test.go
@@ -1,0 +1,189 @@
+package deployment_test
+
+import (
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/werf/kubedog/pkg/tracker/deployment"
+)
+
+func TestTrack_ForeignReplicaSetCannotMaskOwnedReplicaFailure(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	createdAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	foreign := withReplicaSetCreationTimestamp(
+		withReplicaSetControllerUID(newReplicaSet("foreign-111", "foreign-rs-uid"), "foreign-deployment-uid"),
+		createdAt,
+	)
+	h.createObject(t, gvrReplicaSets, foreign)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(foreign.Name)); err != nil {
+		t.Fatalf("wait for foreign AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-owned-not-masked"
+	owned := withReplicaFailure(
+		withReplicaSetCreationTimestamp(newReplicaSet("demo-111", "owned-rs-uid"), createdAt.Add(time.Minute)),
+		"FailedCreate",
+		marker,
+	)
+	h.createObject(t, gvrReplicaSets, owned)
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for owned ReplicaSet failure: %v", err)
+	}
+}
+
+func TestTrack_IgnoresForeignAndOrphanReplicaSetFailures(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	createdAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	const foreignMarker = "marker-foreign-failure"
+	foreign := withReplicaFailure(
+		withReplicaSetCreationTimestamp(
+			withReplicaSetControllerUID(newReplicaSet("foreign-111", "foreign-rs-uid"), "foreign-deployment-uid"),
+			createdAt,
+		),
+		"FailedCreate",
+		foreignMarker,
+	)
+	h.createObject(t, gvrReplicaSets, foreign)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(foreign.Name)); err != nil {
+		t.Fatalf("wait for foreign AddedReplicaSet: %v", err)
+	}
+
+	owned := withReplicaSetCreationTimestamp(newReplicaSet("demo-111", "owned-rs-uid"), createdAt.Add(2*time.Minute))
+	h.createObject(t, gvrReplicaSets, owned)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(owned.Name)); err != nil {
+		t.Fatalf("wait for owned AddedReplicaSet: %v", err)
+	}
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(foreignMarker)); err != nil {
+		t.Fatalf("foreign ReplicaSet must not fail the rollout: %v", err)
+	}
+
+	h.deleteObject(t, gvrReplicaSets, foreign.Name)
+
+	const orphanMarker = "marker-orphan-failure"
+	orphan := withReplicaFailure(
+		withReplicaSetCreationTimestamp(withoutReplicaSetOwner(newReplicaSet("orphan-111", "orphan-rs-uid")), createdAt.Add(time.Minute)),
+		"FailedCreate",
+		orphanMarker,
+	)
+	h.createObject(t, gvrReplicaSets, orphan)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(orphan.Name)); err != nil {
+		t.Fatalf("wait for orphan AddedReplicaSet: %v", err)
+	}
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(orphanMarker)); err != nil {
+		t.Fatalf("orphan ReplicaSet must not fail the rollout: %v", err)
+	}
+}
+
+func TestTrack_DoesNotReportMessageOnlyReplicaFailureChanges(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	const firstMarker = "marker-message-first"
+	failed := withReplicaFailure(rs.DeepCopy(), "FailedCreate", firstMarker)
+	h.updateReplicaSet(t, failed)
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(firstMarker)); err != nil {
+		t.Fatalf("wait for first Failed: %v", err)
+	}
+
+	const changedMarker = "marker-message-changed"
+	messageChanged := failed.DeepCopy()
+	messageChanged.Status.Conditions[0].Message = "updated quota details [" + changedMarker + "]"
+	h.updateReplicaSet(t, messageChanged)
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(changedMarker)); err != nil {
+		t.Fatalf("message-only failure change must not be reported again: %v", err)
+	}
+}
+
+func TestTrack_IgnoresStaleEventsForRecreatedReplicaSet(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rsOld := newReplicaSet("demo-111", "rs-uid-old")
+	h.createObject(t, gvrReplicaSets, rsOld)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rsOld.Name)); err != nil {
+		t.Fatalf("wait for old AddedReplicaSet: %v", err)
+	}
+	h.deleteObject(t, gvrReplicaSets, rsOld.Name)
+
+	const currentMarker = "marker-current-incarnation"
+	rsCurrent := newReplicaSet("demo-111", "rs-uid-current")
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(rsCurrent.DeepCopy(), "FailedCreate", currentMarker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(currentMarker)); err != nil {
+		t.Fatalf("wait for current ReplicaSet failure: %v", err)
+	}
+
+	const staleMarker = "marker-stale-incarnation"
+	h.tracker.TestOnlyInjectReplicaSetModified(withReplicaFailure(rsOld.DeepCopy(), "FailedCreate", staleMarker))
+	h.tracker.TestOnlyInjectReplicaSetDeleted(rsOld.DeepCopy())
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(staleMarker)); err != nil {
+		t.Fatalf("stale ReplicaSet events must not replace the current incarnation: %v", err)
+	}
+
+	h.updateReplicaSet(t, rsCurrent.DeepCopy())
+	const recurringMarker = "marker-current-recurring"
+	h.updateReplicaSet(t, withReplicaFailure(rsCurrent.DeepCopy(), "FailedCreate", recurringMarker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(recurringMarker)); err != nil {
+		t.Fatalf("current ReplicaSet must remain tracked after stale events: %v", err)
+	}
+}
+
+func addedReplicaSetNamed(name string) func(observation) bool {
+	return func(ev observation) bool {
+		report, ok := ev.Data.(deployment.ReplicaSetAddedReport)
+		return ok && report.ReplicaSet.Name == name
+	}
+}
+
+func withReplicaSetControllerUID(rs *appsv1.ReplicaSet, uid types.UID) *appsv1.ReplicaSet {
+	rs.OwnerReferences[0].UID = uid
+	return rs
+}
+
+func withoutReplicaSetOwner(rs *appsv1.ReplicaSet) *appsv1.ReplicaSet {
+	rs.OwnerReferences = nil
+	return rs
+}
+
+func withReplicaSetCreationTimestamp(rs *appsv1.ReplicaSet, createdAt time.Time) *appsv1.ReplicaSet {
+	rs.CreationTimestamp = metav1.NewTime(createdAt)
+	return rs
+}

--- a/pkg/tracker/deployment/tracker_replicaset_test.go
+++ b/pkg/tracker/deployment/tracker_replicaset_test.go
@@ -166,10 +166,330 @@ func TestTrack_IgnoresStaleEventsForRecreatedReplicaSet(t *testing.T) {
 	}
 }
 
+func TestTrack_IgnoresReplicaFailureWhenDeploymentStatusIsReady(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Ready", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Ready: %v", err)
+	}
+
+	const marker = "marker-ready-deployment-wins"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker))
+
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed("demo-111")); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(marker)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTrack_FailsOnReplicaFailureWhileDeploymentIsNotReady(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-not-ready-deployment-fails"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker))
+
+	ev, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker))
+	if err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+
+	status, ok := ev.Data.(deployment.DeploymentStatus)
+	if !ok {
+		t.Fatalf("unexpected Failed payload: %T", ev.Data)
+	}
+	if status.IsReady {
+		t.Fatalf("reported failure must not be ready: %+v", status)
+	}
+
+	if err := h.waitForNone("Ready", 2500*time.Millisecond, nil); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTrack_ReportsReplicaFailureAgainAfterDeploymentStoppedBeingReady(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-readiness-rearms-reporting"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for first Failed: %v", err)
+	}
+
+	h.updateDeployment(t, newReadyDeployment())
+	if _, err := h.waitFor("Ready", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Ready: %v", err)
+	}
+
+	replicaLost := newReadyDeployment()
+	replicaLost.Status.AvailableReplicas = 0
+	replicaLost.Status.UnavailableReplicas = 1
+	h.updateDeployment(t, replicaLost)
+
+	ev, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker))
+	if err != nil {
+		t.Fatalf("a Deployment that stopped being ready must be failed anew by the condition it recovered from: %v", err)
+	}
+
+	status, ok := ev.Data.(deployment.DeploymentStatus)
+	if !ok {
+		t.Fatalf("unexpected Failed payload: %T", ev.Data)
+	}
+	if status.IsReady {
+		t.Fatalf("reported failure must not be ready: %+v", status)
+	}
+	if status.AvailableReplicas != 0 || status.UnavailableReplicas != 1 {
+		t.Fatalf("reported failure must describe the lost replica: %+v", status)
+	}
+}
+
+func TestTrack_ReportsReplicaFailureAgainAfterRollbackToRecoveredReplicaSet(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const firstMarker = "marker-before-rollout"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", firstMarker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(firstMarker)); err != nil {
+		t.Fatalf("wait for first Failed: %v", err)
+	}
+
+	rolledOut := newNotReadyDeployment()
+	rolledOut.Spec.Template.Spec.Containers[0].Image = "busybox:2"
+	rolledOut.Status.Replicas = 1
+	h.updateDeployment(t, rolledOut)
+	if _, err := h.waitFor("Status", 10*time.Second, statusWithReplicas(1)); err != nil {
+		t.Fatalf("wait for rollout Status: %v", err)
+	}
+
+	successor := newReplicaSet("demo-222", "rs-uid-2")
+	successor.Spec.Template.Spec.Containers[0].Image = "busybox:2"
+	h.createObject(t, gvrReplicaSets, successor)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(successor.Name)); err != nil {
+		t.Fatalf("wait for successor AddedReplicaSet: %v", err)
+	}
+
+	h.updateReplicaSet(t, newReplicaSet("demo-111", "rs-uid-1"))
+
+	const secondMarker = "marker-after-rollback"
+	h.updateReplicaSet(t, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", secondMarker))
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(secondMarker)); err != nil {
+		t.Fatalf("previous rollout ReplicaSet must not fail the current rollout: %v", err)
+	}
+
+	h.updateDeployment(t, newNotReadyDeployment())
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(secondMarker)); err != nil {
+		t.Fatalf("failure of the ReplicaSet rolled back onto must be reported anew: %v", err)
+	}
+}
+
+func TestTrack_ReportsReplicaFailureOnceAcrossStatusUpdates(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-reported-once"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+
+	dep := newNotReadyDeployment()
+	dep.Status.Replicas = 1
+	h.updateDeployment(t, dep)
+
+	ev, err := h.waitFor("Status", 10*time.Second, statusWithReplicas(1))
+	if err != nil {
+		t.Fatalf("wait for Status: %v", err)
+	}
+	status, ok := ev.Data.(deployment.DeploymentStatus)
+	if !ok {
+		t.Fatalf("unexpected Status payload: %T", ev.Data)
+	}
+	if status.IsFailed || status.FailedReason != "" {
+		t.Fatalf("routine status must not carry the already reported failure: %+v", status)
+	}
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(marker)); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestTrack_StopsReportingWithdrawnReplicaFailure(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	const withdrawnMarker = "marker-withdrawn"
+	h.updateReplicaSet(t, withReplicaFailure(rs.DeepCopy(), "FailedCreate", withdrawnMarker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(withdrawnMarker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+
+	h.updateReplicaSet(t, rs.DeepCopy())
+
+	dep := newNotReadyDeployment()
+	dep.Status.Replicas = 1
+	h.updateDeployment(t, dep)
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(withdrawnMarker)); err != nil {
+		t.Fatal(err)
+	}
+
+	const rearmedMarker = "marker-rearmed"
+	h.updateReplicaSet(t, withReplicaFailure(rs.DeepCopy(), "FailedCreate", rearmedMarker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(rearmedMarker)); err != nil {
+		t.Fatalf("failure must be reported again after the condition reappeared: %v", err)
+	}
+}
+
+func TestTrack_IgnoresStaleModifiedDeliveredAfterReplicaSetDeletion(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	createdAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	rsOld := withReplicaSetCreationTimestamp(newReplicaSet("demo-111", "rs-uid-old"), createdAt)
+	h.createObject(t, gvrReplicaSets, rsOld)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(rsOld.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	h.injectReplicaSetDeletedAndWait(t, rsOld.DeepCopy())
+
+	rsCurrent := withReplicaSetCreationTimestamp(newReplicaSet("demo-222", "rs-uid-current"), createdAt.Add(time.Minute))
+	h.createObject(t, gvrReplicaSets, rsCurrent)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(rsCurrent.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	const staleMarker = "marker-stale"
+	h.tracker.TestOnlyInjectReplicaSetModified(withReplicaFailure(rsOld.DeepCopy(), "FailedCreate", staleMarker))
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(staleMarker)); err != nil {
+		t.Fatal(err)
+	}
+
+	const currentMarker = "marker-current"
+	h.updateReplicaSet(t, withReplicaFailure(rsCurrent.DeepCopy(), "FailedCreate", currentMarker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(currentMarker)); err != nil {
+		t.Fatalf("current ReplicaSet must remain tracked after the stale event: %v", err)
+	}
+}
+
+func TestTrack_ReportsFailureOfReplicaSetPromotedByDeletion(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	createdAt := time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC)
+	current := withReplicaSetCreationTimestamp(newReplicaSet("demo-111", "rs-uid-current"), createdAt)
+	h.createObject(t, gvrReplicaSets, current)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(current.Name)); err != nil {
+		t.Fatalf("wait for current AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-promoted-by-deletion"
+	duplicate := withReplicaFailure(
+		withReplicaSetCreationTimestamp(newReplicaSet("demo-222", "rs-uid-duplicate"), createdAt.Add(time.Minute)),
+		"FailedCreate",
+		marker,
+	)
+	h.createObject(t, gvrReplicaSets, duplicate)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedReplicaSetNamed(duplicate.Name)); err != nil {
+		t.Fatalf("wait for duplicate AddedReplicaSet: %v", err)
+	}
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(marker)); err != nil {
+		t.Fatalf("a ReplicaSet that is not the new one must not fail the rollout: %v", err)
+	}
+
+	h.deleteObject(t, gvrReplicaSets, current.Name)
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("failure of the ReplicaSet promoted by the deletion must be reported: %v", err)
+	}
+}
+
+func TestTrack_PreservesReplicaSetEventOrderAcrossChannels(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	const initialMarker = "marker-initial-failure"
+	const recurringMarker = "marker-recurring-failure"
+
+	// Occupies the tracker so the events below arrive while it is busy: only then can
+	// buffered fan-out channels reorder them and make this test a discriminator.
+	h.tracker.TestOnlyInjectResourceFailure("keeps the tracker busy")
+	h.tracker.TestOnlyInjectReplicaSetAdded(withReplicaFailure(rs.DeepCopy(), "FailedCreate", initialMarker))
+	h.tracker.TestOnlyInjectReplicaSetModified(rs.DeepCopy())
+	h.tracker.TestOnlyInjectReplicaSetModified(withReplicaFailure(rs.DeepCopy(), "FailedCreate", recurringMarker))
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(initialMarker)); err != nil {
+		t.Fatalf("initial failure must be reported despite fan-out across channels: %v", err)
+	}
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(recurringMarker)); err != nil {
+		t.Fatalf("failure recurring after recovery must be reported anew: %v", err)
+	}
+}
+
 func addedReplicaSetNamed(name string) func(observation) bool {
 	return func(ev observation) bool {
 		report, ok := ev.Data.(deployment.ReplicaSetAddedReport)
 		return ok && report.ReplicaSet.Name == name
+	}
+}
+
+func statusWithReplicas(replicas int32) func(observation) bool {
+	return func(ev observation) bool {
+		status, ok := ev.Data.(deployment.DeploymentStatus)
+		return ok && status.Replicas == replicas
 	}
 }
 

--- a/pkg/tracker/deployment/tracker_test.go
+++ b/pkg/tracker/deployment/tracker_test.go
@@ -1,0 +1,273 @@
+package deployment_test
+
+import (
+	"testing"
+	"time"
+
+	"k8s.io/apimachinery/pkg/runtime"
+
+	"github.com/werf/kubedog/pkg/tracker/deployment"
+)
+
+func TestTrack_FailsOnNewReplicaSetReplicaFailure(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-happy-path"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker))
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+}
+
+func TestTrack_FailsOnReplicaFailureAppearingAfterReplicaSetAdded(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-condition-after-add"
+	h.updateReplicaSet(t, withReplicaFailure(rs.DeepCopy(), "FailedCreate", marker))
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+}
+
+// Models the apply-then-track gap: the ReplicaSet already carries the failure
+// condition when tracking starts, so unlike a Warning event there is no history
+// to replay and no start boundary to reason about.
+func TestTrack_FailsOnPreexistingReplicaFailure(t *testing.T) {
+	const marker = "marker-preexisting"
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{
+			newNotReadyDeployment(),
+			withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker),
+		},
+	})
+
+	if _, err := h.waitFor("Failed", 15*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+}
+
+func TestTrack_IgnoresOldReplicaSetReplicaFailure(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rsOld := newReplicaSet("demo-old", "rs-old")
+	h.createObject(t, gvrReplicaSets, rsOld)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rsOld.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet(old): %v", err)
+	}
+
+	updatedDep := newNotReadyDeployment()
+	updatedDep.Generation = 2
+	updatedDep.Status.ObservedGeneration = 2
+	updatedDep.Spec.Template.Spec.Containers[0].Image = "busybox:2"
+	h.updateDeployment(t, updatedDep)
+	if _, err := h.waitFor("Status", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Status after deployment update: %v", err)
+	}
+
+	rsNew := newReplicaSet("demo-new", "rs-new")
+	rsNew.Spec.Template.Spec.Containers[0].Image = "busybox:2"
+	h.createObject(t, gvrReplicaSets, rsNew)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rsNew.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet(new): %v", err)
+	}
+
+	const markerOld = "marker-old-rollout"
+	h.updateReplicaSet(t, withReplicaFailure(rsOld.DeepCopy(), "FailedCreate", markerOld))
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(markerOld)); err != nil {
+		t.Fatalf("previous rollout replicaset must not fail the current one: %v", err)
+	}
+
+	const markerNew = "marker-new-rollout"
+	h.updateReplicaSet(t, withReplicaFailure(rsNew.DeepCopy(), "FailedCreate", markerNew))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(markerNew)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+}
+
+func TestTrack_ReportsReplicaFailureOncePerIncarnation(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-dedupe"
+	failed := withReplicaFailure(rs.DeepCopy(), "FailedCreate", marker)
+	h.updateReplicaSet(t, failed)
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+
+	stillFailing := failed.DeepCopy()
+	stillFailing.Status.ObservedGeneration = 2
+	h.updateReplicaSet(t, stillFailing)
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(marker)); err != nil {
+		t.Fatalf("unchanged failure condition must not be reported twice: %v", err)
+	}
+}
+
+func TestTrack_ReportsReplicaFailureAgainAfterConditionCleared(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	const marker = "marker-rearm"
+	h.updateReplicaSet(t, withReplicaFailure(rs.DeepCopy(), "FailedCreate", marker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for first Failed: %v", err)
+	}
+
+	h.updateReplicaSet(t, rs.DeepCopy())
+	h.updateReplicaSet(t, withReplicaFailure(rs.DeepCopy(), "FailedCreate", marker))
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("failure recurring after recovery must be reported again: %v", err)
+	}
+}
+
+func TestTrack_IgnoresFailedDeleteReplicaFailure(t *testing.T) {
+	const marker = "marker-failed-delete"
+	rs := withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedDelete", marker)
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment(), rs},
+	})
+
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(marker)); err != nil {
+		t.Fatalf("FailedDelete must not fail the rollout: %v", err)
+	}
+}
+
+func TestTrack_FailsOnReplicaFailureWithEventsDisabled(t *testing.T) {
+	t.Setenv("KUBEDOG_DISABLE_EVENTS", "1")
+
+	const marker = "marker-events-disabled"
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{
+			newNotReadyDeployment(),
+			withReplicaFailure(newReplicaSet("demo-111", "rs-uid-1"), "FailedCreate", marker),
+		},
+	})
+
+	if _, err := h.waitFor("Failed", 15*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("replica failure detection must not depend on events: %v", err)
+	}
+}
+
+func TestTrack_FailsOnRecreatedReplicaSetWithSameNameNewUID(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rsOld := newReplicaSet("demo-111", "rs-uid-old")
+	h.createObject(t, gvrReplicaSets, rsOld)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rsOld.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet(old): %v", err)
+	}
+
+	h.deleteObject(t, gvrReplicaSets, rsOld.Name)
+
+	const marker = "marker-recreated-rs"
+	h.createObject(t, gvrReplicaSets, withReplicaFailure(newReplicaSet("demo-111", "rs-uid-new"), "FailedCreate", marker))
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMarker(marker)); err != nil {
+		t.Fatalf("wait for Failed: %v", err)
+	}
+}
+
+func TestTrack_StopsReportingReplicaFailuresAfterDeploymentDeletion(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	rs := newReplicaSet("demo-111", "rs-uid-1")
+	h.createObject(t, gvrReplicaSets, rs)
+	if _, err := h.waitFor("AddedReplicaSet", 10*time.Second, addedNewReplicaSet(rs.Name)); err != nil {
+		t.Fatalf("wait for AddedReplicaSet: %v", err)
+	}
+
+	h.deleteObject(t, gvrDeployments, testDeploymentName)
+	if _, err := h.waitFor("Status", 10*time.Second, deletionResetStatus); err != nil {
+		t.Fatalf("wait for deletion status: %v", err)
+	}
+
+	const marker = "marker-after-deletion"
+	h.updateReplicaSet(t, withReplicaFailure(rs.DeepCopy(), "FailedCreate", marker))
+	if err := h.waitForNone("Failed", 2500*time.Millisecond, failedWithMarker(marker)); err != nil {
+		t.Fatalf("replica failures must not be reported for a deleted deployment: %v", err)
+	}
+}
+
+func addedNewReplicaSet(name string) func(observation) bool {
+	return func(ev observation) bool {
+		report, ok := ev.Data.(deployment.ReplicaSetAddedReport)
+		if !ok {
+			return false
+		}
+		return report.ReplicaSet.Name == name && report.ReplicaSet.IsNew
+	}
+}
+
+// The zero-value status emitted on resource deletion is the only Status with
+// StatusGeneration == 0, since NewDeploymentStatus always increments it first.
+func deletionResetStatus(ev observation) bool {
+	status, ok := ev.Data.(deployment.DeploymentStatus)
+	if !ok {
+		return false
+	}
+	return status.StatusGeneration == 0 && !status.IsFailed
+}

--- a/pkg/tracker/deployment/tracker_test.go
+++ b/pkg/tracker/deployment/tracker_test.go
@@ -200,6 +200,23 @@ func TestTrack_FailsOnReplicaFailureWithEventsDisabled(t *testing.T) {
 	}
 }
 
+func TestTrack_ReportsEventFailureAsCounted(t *testing.T) {
+	h := newHarness(t, harnessConfig{
+		dynamicSeed: []runtime.Object{newNotReadyDeployment()},
+	})
+
+	if _, err := h.waitFor("Added", 10*time.Second, nil); err != nil {
+		t.Fatalf("wait for Added: %v", err)
+	}
+
+	const marker = "marker-counted-event-failure"
+	h.tracker.TestOnlyInjectResourceFailure(marker)
+
+	if _, err := h.waitFor("Failed", 10*time.Second, failedWithMode(marker, deployment.FailureModeCounted)); err != nil {
+		t.Fatalf("event failure must remain subject to the error budget: %v", err)
+	}
+}
+
 func TestTrack_FailsOnRecreatedReplicaSetWithSameNameNewUID(t *testing.T) {
 	h := newHarness(t, harnessConfig{
 		dynamicSeed: []runtime.Object{newNotReadyDeployment()},

--- a/pkg/tracker/replicaset/informer.go
+++ b/pkg/tracker/replicaset/informer.go
@@ -44,11 +44,13 @@ type ReplicaSetPodError struct {
 // ReplicaSetInformer monitor ReplicaSet events to use with controllers (Deployment, StatefulSet, DaemonSet)
 type ReplicaSetInformer struct {
 	tracker.Tracker
-	Controller         utils.ControllerMetadata
-	ReplicaSetAdded    chan *appsv1.ReplicaSet
-	ReplicaSetModified chan *appsv1.ReplicaSet
-	ReplicaSetDeleted  chan *appsv1.ReplicaSet
-	Errors             chan error
+	Controller           utils.ControllerMetadata
+	ReplicaSetAdded      chan *appsv1.ReplicaSet
+	ReplicaSetModified   chan *appsv1.ReplicaSet
+	ReplicaSetDeleted    chan *appsv1.ReplicaSet
+	replicaSetUnselected chan *appsv1.ReplicaSet
+	replicaSetSynced     chan struct{}
+	Errors               chan error
 }
 
 func NewReplicaSetInformer(trk *tracker.Tracker, controller utils.ControllerMetadata) *ReplicaSetInformer {
@@ -81,7 +83,29 @@ func (r *ReplicaSetInformer) WithChannels(added chan *appsv1.ReplicaSet,
 	return r
 }
 
+// WithUnselectedChannel reports ReplicaSets that stop matching the controller selector
+// without being deleted. Consumers can remove them without permanently tombstoning the UID.
+func (r *ReplicaSetInformer) WithUnselectedChannel(unselected chan *appsv1.ReplicaSet) *ReplicaSetInformer {
+	r.replicaSetUnselected = unselected
+	return r
+}
+
+// WithSyncedChannel reports when this handler has consumed its initial ReplicaSet list.
+func (r *ReplicaSetInformer) WithSyncedChannel(synced chan struct{}) *ReplicaSetInformer {
+	r.replicaSetSynced = synced
+	return r
+}
+
 func (r *ReplicaSetInformer) Run(ctx context.Context) (cleanupFn func(), err error) {
+	// The event channels may be unbuffered, so a send with no receiver left blocks the
+	// shared informer goroutine forever: stop sending once the consumer is gone.
+	ctx, stopSending := context.WithCancel(ctx)
+	defer func() {
+		if err != nil {
+			stopSending()
+		}
+	}()
+
 	var inform *util.Concurrent[*informer.Informer]
 	if err := r.InformerFactory.RWTransactionErr(func(factory *informer.InformerFactory) error {
 		inform, err = factory.ForNamespace(schema.GroupVersionResource{
@@ -104,45 +128,58 @@ func (r *ReplicaSetInformer) Run(ctx context.Context) (cleanupFn func(), err err
 	}
 
 	if err := inform.RWTransactionErr(func(inf *informer.Informer) error {
+		toReplicaSet := func(obj interface{}) *appsv1.ReplicaSet {
+			if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
+				obj = d.Obj
+			}
+
+			rsObj := &appsv1.ReplicaSet{}
+			lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, rsObj))
+			return rsObj
+		}
+		matches := func(rs *appsv1.ReplicaSet) bool {
+			return labelSelector.Matches(apilabels.Set(rs.GetLabels()))
+		}
+
 		handler, err := inf.AddEventHandler(
-			cache.FilteringResourceEventHandler{
-				FilterFunc: func(obj interface{}) bool {
-					if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-						obj = d.Obj
+			cache.ResourceEventHandlerFuncs{
+				AddFunc: func(obj interface{}) {
+					rsObj := toReplicaSet(obj)
+					if matches(rsObj) {
+						sendReplicaSet(ctx, r.ReplicaSetAdded, rsObj)
 					}
-
-					rsObj := &appsv1.ReplicaSet{}
-					lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, rsObj))
-					return labelSelector.Matches(apilabels.Set(rsObj.GetLabels()))
 				},
-				Handler: cache.ResourceEventHandlerFuncs{
-					AddFunc: func(obj interface{}) {
-						if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-							obj = d.Obj
-						}
+				UpdateFunc: func(oldObj, newObj interface{}) {
+					oldReplicaSet := toReplicaSet(oldObj)
+					newReplicaSet := toReplicaSet(newObj)
+					oldMatches := matches(oldReplicaSet)
+					newMatches := matches(newReplicaSet)
 
-						rsObj := &appsv1.ReplicaSet{}
-						lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, rsObj))
-						r.ReplicaSetAdded <- rsObj
-					},
-					UpdateFunc: func(oldObj, newObj interface{}) {
-						if d, ok := newObj.(cache.DeletedFinalStateUnknown); ok {
-							newObj = d.Obj
+					switch {
+					case oldReplicaSet.UID != newReplicaSet.UID:
+						if oldMatches {
+							sendReplicaSet(ctx, r.ReplicaSetDeleted, oldReplicaSet)
 						}
-
-						rsObj := &appsv1.ReplicaSet{}
-						lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(newObj.(*unstructured.Unstructured).Object, rsObj))
-						r.ReplicaSetModified <- rsObj
-					},
-					DeleteFunc: func(obj interface{}) {
-						if d, ok := obj.(cache.DeletedFinalStateUnknown); ok {
-							obj = d.Obj
+						if newMatches {
+							sendReplicaSet(ctx, r.ReplicaSetAdded, newReplicaSet)
 						}
-
-						rsObj := &appsv1.ReplicaSet{}
-						lo.Must0(runtime.DefaultUnstructuredConverter.FromUnstructured(obj.(*unstructured.Unstructured).Object, rsObj))
-						r.ReplicaSetDeleted <- rsObj
-					},
+					case oldMatches && newMatches:
+						sendReplicaSet(ctx, r.ReplicaSetModified, newReplicaSet)
+					case oldMatches:
+						if r.replicaSetUnselected != nil {
+							sendReplicaSet(ctx, r.replicaSetUnselected, newReplicaSet)
+						} else {
+							sendReplicaSet(ctx, r.ReplicaSetDeleted, oldReplicaSet)
+						}
+					case newMatches:
+						sendReplicaSet(ctx, r.ReplicaSetAdded, newReplicaSet)
+					}
+				},
+				DeleteFunc: func(obj interface{}) {
+					rsObj := toReplicaSet(obj)
+					if matches(rsObj) {
+						sendReplicaSet(ctx, r.ReplicaSetDeleted, rsObj)
+					}
 				},
 			},
 		)
@@ -151,10 +188,23 @@ func (r *ReplicaSetInformer) Run(ctx context.Context) (cleanupFn func(), err err
 		}
 
 		cleanupFn = func() {
+			stopSending()
 			inf.RemoveEventHandler(handler)
 		}
 
 		inf.Run()
+		if r.replicaSetSynced != nil {
+			go func() {
+				if !cache.WaitForCacheSync(ctx.Done(), handler.HasSynced) {
+					return
+				}
+
+				select {
+				case r.replicaSetSynced <- struct{}{}:
+				case <-ctx.Done():
+				}
+			}()
+		}
 
 		return nil
 	}); err != nil {
@@ -162,4 +212,11 @@ func (r *ReplicaSetInformer) Run(ctx context.Context) (cleanupFn func(), err err
 	}
 
 	return cleanupFn, nil
+}
+
+func sendReplicaSet(ctx context.Context, ch chan<- *appsv1.ReplicaSet, rsObj *appsv1.ReplicaSet) {
+	select {
+	case ch <- rsObj:
+	case <-ctx.Done():
+	}
 }

--- a/pkg/tracker/replicaset/informer_lifecycle_test.go
+++ b/pkg/tracker/replicaset/informer_lifecycle_test.go
@@ -1,0 +1,217 @@
+package replicaset
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/werf/kubedog/pkg/informer"
+	"github.com/werf/kubedog/pkg/tracker"
+	"github.com/werf/kubedog/pkg/utils"
+)
+
+var lifecycleReplicaSetGVR = schema.GroupVersionResource{Group: "apps", Version: "v1", Resource: "replicasets"}
+
+type lifecycleInformerHarness struct {
+	ctx        context.Context
+	dynamic    dynamic.Interface
+	added      chan *appsv1.ReplicaSet
+	modified   chan *appsv1.ReplicaSet
+	deleted    chan *appsv1.ReplicaSet
+	unselected chan *appsv1.ReplicaSet
+	synced     chan struct{}
+}
+
+func TestRun_whenInitialReplicaSetsAreConsumed(t *testing.T) {
+	replicaSet := lifecycleReplicaSet("demo-111", "rs-uid-1")
+	h := newLifecycleInformerHarness(t, replicaSet)
+
+	select {
+	case <-h.synced:
+		t.Fatal("handler reported synced before its initial Add was consumed")
+	default:
+	}
+
+	receiveReplicaSet(t, h.added)
+	select {
+	case <-h.synced:
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for handler sync")
+	}
+}
+
+func TestRun_whenUpdateReplacesReplicaSetUID(t *testing.T) {
+	oldReplicaSet := lifecycleReplicaSet("demo-111", "rs-uid-old")
+	h := newLifecycleInformerHarness(t, oldReplicaSet)
+
+	if got := receiveReplicaSet(t, h.added); got.UID != oldReplicaSet.UID {
+		t.Fatalf("initial Added UID = %q, want %q", got.UID, oldReplicaSet.UID)
+	}
+
+	newReplicaSet := oldReplicaSet.DeepCopy()
+	newReplicaSet.UID = types.UID("rs-uid-new")
+	updateLifecycleReplicaSet(t, h, newReplicaSet)
+
+	if got := receiveReplicaSet(t, h.deleted); got.UID != oldReplicaSet.UID {
+		t.Fatalf("replacement Deleted UID = %q, want %q", got.UID, oldReplicaSet.UID)
+	}
+	if got := receiveReplicaSet(t, h.added); got.UID != newReplicaSet.UID {
+		t.Fatalf("replacement Added UID = %q, want %q", got.UID, newReplicaSet.UID)
+	}
+}
+
+func TestRun_whenReplacementStopsMatchingSelector(t *testing.T) {
+	oldReplicaSet := lifecycleReplicaSet("demo-111", "rs-uid-old")
+	h := newLifecycleInformerHarness(t, oldReplicaSet)
+
+	if got := receiveReplicaSet(t, h.added); got.UID != oldReplicaSet.UID {
+		t.Fatalf("initial Added UID = %q, want %q", got.UID, oldReplicaSet.UID)
+	}
+
+	replacement := oldReplicaSet.DeepCopy()
+	replacement.UID = types.UID("rs-uid-new")
+	replacement.Labels = map[string]string{"app": "other"}
+	updateLifecycleReplicaSet(t, h, replacement)
+
+	if got := receiveReplicaSet(t, h.deleted); got.UID != oldReplicaSet.UID {
+		t.Fatalf("replacement Deleted UID = %q, want %q", got.UID, oldReplicaSet.UID)
+	}
+}
+
+func TestRun_whenReplicaSetLeavesAndReentersSelector(t *testing.T) {
+	replicaSet := lifecycleReplicaSet("demo-111", "rs-uid-1")
+	h := newLifecycleInformerHarness(t, replicaSet)
+
+	if got := receiveReplicaSet(t, h.added); got.UID != replicaSet.UID {
+		t.Fatalf("initial Added UID = %q, want %q", got.UID, replicaSet.UID)
+	}
+
+	unselected := replicaSet.DeepCopy()
+	unselected.Labels = map[string]string{"app": "other"}
+	updateLifecycleReplicaSet(t, h, unselected)
+	if got := receiveReplicaSet(t, h.unselected); got.UID != replicaSet.UID {
+		t.Fatalf("Unselected UID = %q, want %q", got.UID, replicaSet.UID)
+	}
+
+	reentered := replicaSet.DeepCopy()
+	updateLifecycleReplicaSet(t, h, reentered)
+	if got := receiveReplicaSet(t, h.added); got.UID != replicaSet.UID {
+		t.Fatalf("reentry Added UID = %q, want %q", got.UID, replicaSet.UID)
+	}
+}
+
+func newLifecycleInformerHarness(t *testing.T, seed *appsv1.ReplicaSet) *lifecycleInformerHarness {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	dynClient := dynamicfake.NewSimpleDynamicClient(k8sscheme.Scheme, seed)
+	watchErrCh := make(chan error, 10)
+	factory := informer.NewConcurrentInformerFactory(ctx.Done(), watchErrCh, dynClient, informer.ConcurrentInformerFactoryOptions{})
+	dep := lifecycleDeployment()
+
+	h := &lifecycleInformerHarness{
+		ctx:        ctx,
+		dynamic:    dynClient,
+		added:      make(chan *appsv1.ReplicaSet),
+		modified:   make(chan *appsv1.ReplicaSet),
+		deleted:    make(chan *appsv1.ReplicaSet),
+		unselected: make(chan *appsv1.ReplicaSet),
+		synced:     make(chan struct{}),
+	}
+
+	rsInformer := NewReplicaSetInformer(&tracker.Tracker{
+		Namespace:       testNamespace,
+		ResourceName:    dep.Name,
+		InformerFactory: factory,
+	}, utils.ControllerAccessor(dep)).WithChannels(h.added, h.modified, h.deleted, watchErrCh).
+		WithUnselectedChannel(h.unselected).
+		WithSyncedChannel(h.synced)
+
+	cleanup, err := rsInformer.Run(ctx)
+	if err != nil {
+		t.Fatalf("run ReplicaSet informer: %v", err)
+	}
+	t.Cleanup(cleanup)
+
+	return h
+}
+
+func updateLifecycleReplicaSet(t *testing.T, h *lifecycleInformerHarness, rs *appsv1.ReplicaSet) {
+	t.Helper()
+
+	current, err := h.dynamic.Resource(lifecycleReplicaSetGVR).Namespace(testNamespace).Get(h.ctx, rs.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("get ReplicaSet: %v", err)
+	}
+	rs.ResourceVersion = current.GetResourceVersion()
+
+	object, err := runtime.DefaultUnstructuredConverter.ToUnstructured(rs)
+	if err != nil {
+		t.Fatalf("convert ReplicaSet: %v", err)
+	}
+	if _, err := h.dynamic.Resource(lifecycleReplicaSetGVR).Namespace(testNamespace).Update(
+		h.ctx,
+		&unstructured.Unstructured{Object: object},
+		metav1.UpdateOptions{},
+	); err != nil {
+		t.Fatalf("update ReplicaSet: %v", err)
+	}
+}
+
+func receiveReplicaSet(t *testing.T, ch <-chan *appsv1.ReplicaSet) *appsv1.ReplicaSet {
+	t.Helper()
+
+	select {
+	case rs := <-ch:
+		return rs
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for ReplicaSet event")
+		return nil
+	}
+}
+
+func lifecycleDeployment() *appsv1.Deployment {
+	return &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: testNamespace, UID: types.UID("dep-uid-1")},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+		},
+	}
+}
+
+func lifecycleReplicaSet(name string, uid types.UID) *appsv1.ReplicaSet {
+	dep := lifecycleDeployment()
+	return &appsv1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: testNamespace,
+			UID:       uid,
+			Labels:    map[string]string{"app": "demo"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: dep.Name, UID: dep.UID, Controller: ptrTo(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: dep.Spec.Selector,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox:1"}}},
+			},
+		},
+	}
+}

--- a/pkg/tracker/replicaset/informer_test.go
+++ b/pkg/tracker/replicaset/informer_test.go
@@ -1,0 +1,115 @@
+package replicaset
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+
+	"github.com/werf/kubedog/pkg/informer"
+	"github.com/werf/kubedog/pkg/tracker"
+	"github.com/werf/kubedog/pkg/utils"
+)
+
+const testNamespace = "default"
+
+// callbackFrame matches a goroutine parked inside an event callback. Matching the file
+// instead of a function name keeps the check honest whether the send sits in the
+// callback itself or in a helper.
+const callbackFrame = "pkg/tracker/replicaset/informer.go:"
+
+func TestRun_UnblocksEventCallbackOnCleanup(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	dep := &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Name: "demo", Namespace: testNamespace, UID: types.UID("dep-uid-1")},
+		Spec: appsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "demo"}},
+		},
+	}
+	rs := &appsv1.ReplicaSet{
+		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "demo-111",
+			Namespace: testNamespace,
+			UID:       types.UID("rs-uid-1"),
+			Labels:    map[string]string{"app": "demo"},
+			OwnerReferences: []metav1.OwnerReference{{
+				APIVersion: "apps/v1", Kind: "Deployment", Name: dep.Name, UID: dep.UID, Controller: ptrTo(true),
+			}},
+		},
+		Spec: appsv1.ReplicaSetSpec{
+			Selector: dep.Spec.Selector,
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{Labels: map[string]string{"app": "demo"}},
+				Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "c", Image: "busybox:1"}}},
+			},
+		},
+	}
+
+	dynClient := dynamicfake.NewSimpleDynamicClient(k8sscheme.Scheme, rs)
+	watchErrCh := make(chan error, 10)
+	factory := informer.NewConcurrentInformerFactory(ctx.Done(), watchErrCh, dynClient, informer.ConcurrentInformerFactoryOptions{})
+
+	rsInformer := NewReplicaSetInformer(&tracker.Tracker{
+		Namespace:       testNamespace,
+		ResourceName:    dep.Name,
+		InformerFactory: factory,
+	}, utils.ControllerAccessor(dep)).WithChannels(
+		make(chan *appsv1.ReplicaSet),
+		make(chan *appsv1.ReplicaSet),
+		make(chan *appsv1.ReplicaSet),
+		make(chan error),
+	)
+
+	cleanupFn, err := rsInformer.Run(ctx)
+	if err != nil {
+		t.Fatalf("run replicaset informer: %v", err)
+	}
+
+	if !waitForCallbackParked(true, 10*time.Second) {
+		t.Fatal("no event callback parked on send: the test cannot tell whether cleanup releases one")
+	}
+
+	cleanupFn()
+
+	if !waitForCallbackParked(false, 10*time.Second) {
+		t.Fatal("event callback still parked 10s after cleanup: the shared informer goroutine is wedged")
+	}
+}
+
+func waitForCallbackParked(want bool, timeout time.Duration) bool {
+	deadline := time.Now().Add(timeout)
+	for {
+		if callbackParked() == want {
+			return true
+		}
+		if time.Now().After(deadline) {
+			return false
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func callbackParked() bool {
+	buf := make([]byte, 64*1024)
+	for {
+		n := runtime.Stack(buf, true)
+		if n < len(buf) {
+			return strings.Contains(string(buf[:n]), callbackFrame)
+		}
+		buf = make([]byte, 2*len(buf))
+	}
+}
+
+func ptrTo[T any](v T) *T { return &v }

--- a/pkg/utils/deployment_utils.go
+++ b/pkg/utils/deployment_utils.go
@@ -7,21 +7,44 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// FindNewReplicaSet returns the ReplicaSet the Deployment is currently rolling out.
+//
+// Only ReplicaSets controlled by the Deployment are considered: label selectors are
+// not unique, so a ReplicaSet of another Deployment or of a previous incarnation of
+// this one may match both the labels and the pod template.
 func FindNewReplicaSet(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSet) (*appsv1.ReplicaSet, error) {
 	newRSTemplate := GetNewReplicaSetTemplate(deployment)
-	sort.Sort(ReplicaSetsByCreationTimestamp(rsList))
-	for i := range rsList {
-		if EqualIgnoreHash(rsList[i].Spec.Template, newRSTemplate) {
+	ownedRSList := controlledReplicaSets(deployment, rsList)
+	sort.Sort(ReplicaSetsByCreationTimestamp(ownedRSList))
+	for i := range ownedRSList {
+		if EqualIgnoreHash(ownedRSList[i].Spec.Template, newRSTemplate) {
 			// In rare cases, such as after cluster upgrades, Deployment may end up with
 			// having more than one new ReplicaSets that have the same template as its template,
 			// see https://github.com/kubernetes/kubernetes/issues/40415
 			// We deterministically choose the oldest new ReplicaSet.
-			return rsList[i], nil
+			return ownedRSList[i], nil
 		}
 	}
 	return nil, nil
+}
+
+// controlledReplicaSets keeps only the ReplicaSets whose controller reference points
+// at the given Deployment. A ReplicaSet without a controller reference is not
+// adopted, just like the Deployment controller itself does not adopt one.
+func controlledReplicaSets(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSet) []*appsv1.ReplicaSet {
+	ownedRSList := make([]*appsv1.ReplicaSet, 0, len(rsList))
+	for _, rs := range rsList {
+		if rs == nil || !metav1.IsControlledBy(rs, deployment) {
+			continue
+		}
+
+		ownedRSList = append(ownedRSList, rs)
+	}
+
+	return ownedRSList
 }
 
 func IsReplicaSetNew(deployment *appsv1.Deployment, rsMap map[string]*appsv1.ReplicaSet, rsName string) (bool, error) {

--- a/pkg/utils/deployment_utils.go
+++ b/pkg/utils/deployment_utils.go
@@ -11,10 +11,8 @@ import (
 )
 
 // FindNewReplicaSet returns the ReplicaSet the Deployment is currently rolling out.
-//
-// Only ReplicaSets controlled by the Deployment are considered: label selectors are
-// not unique, so a ReplicaSet of another Deployment or of a previous incarnation of
-// this one may match both the labels and the pod template.
+// Only controlled ReplicaSets are considered: label selectors are not unique, so a
+// ReplicaSet of another Deployment may match both the labels and the pod template.
 func FindNewReplicaSet(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSet) (*appsv1.ReplicaSet, error) {
 	newRSTemplate := GetNewReplicaSetTemplate(deployment)
 	ownedRSList := controlledReplicaSets(deployment, rsList)
@@ -31,9 +29,9 @@ func FindNewReplicaSet(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSe
 	return nil, nil
 }
 
-// controlledReplicaSets keeps only the ReplicaSets whose controller reference points
-// at the given Deployment. A ReplicaSet without a controller reference is not
-// adopted, just like the Deployment controller itself does not adopt one.
+// controlledReplicaSets keeps only the ReplicaSets owned by the Deployment. Adoption of an
+// orphan is left to the Deployment controller: tracking one before it happens would report
+// a ReplicaSet that may never become ours.
 func controlledReplicaSets(deployment *appsv1.Deployment, rsList []*appsv1.ReplicaSet) []*appsv1.ReplicaSet {
 	ownedRSList := make([]*appsv1.ReplicaSet, 0, len(rsList))
 	for _, rs := range rsList {


### PR DESCRIPTION
This PR makes the Deployment tracker observe ReplicaSet pod-create failures such as `FailedCreate ... exceeded quota` instead of waiting for the tracking timeout.

The ReplicaSet controller reports these failures on the ReplicaSet, while the Deployment tracker previously watched only the Deployment object and its events. StatefulSet and DaemonSet tracking are unaffected because their controllers report `FailedCreate` on the object kubedog already watches.

## Behavior

- Read `FailedCreate` from the durable `ReplicaSetReplicaFailure` condition. This catches failures that predate informer startup and works with `KUBEDOG_DISABLE_EVENTS=1`.
- Treat invalid specs and quota failures with no rollout path to release quota as fatal immediately.
- Keep rollout-recoverable quota failures counted against the allowed-failures budget. The first classification stays latched until the condition clears and reappears, because Kubernetes can retain a stale `FailedCreate` condition while retrying.
- Account for `TerminatingReplicas` when deciding whether an old ReplicaSet can release quota for the rollout.
- Wait for the complete initial ReplicaSet snapshot before classifying failures.
- Track ReplicaSet incarnations by UID, handle same-name replacement, and preserve failures across selector leave/reentry without accepting stale events.
- Preserve informer ordering with unbuffered, cancellation-aware sends so cleanup cannot leave the shared informer goroutine blocked.
- Keep the original failure reason and message in the reported diagnostic.
- Mark a fatal resource state as failed only for fail modes that should stop the deploy process. `IgnoreAndContinueDeployProcess` remains unchanged.

Only ReplicaSets controlled by the tracked Deployment are considered, because label selectors alone are not unique.

## Verification

- `go build ./...`
- `go test ./...`
- Race-enabled tests for the Deployment, ReplicaSet, dynamic tracker, and utility packages
- `go vet` on the changed package trees
- Lifecycle coverage for initial sync, failure classification, recovery, UID replacement, selector reentry, stale conditions, successor promotion, and informer cleanup
- kind reproduction with a `ResourceQuota` of `pods: 0`: tracking previously waited for the timeout and now returns the original `FailedCreate` quota diagnostic within seconds

Closes #398
Refs #216, #363
