### PR TITLE
fix: switch managed-services.deckhouse.io readiness tracking to Available only

### DIFF
--- a/pkg/tracker/generic/contrib_resource_status_rules.yaml
+++ b/pkg/tracker/generic/contrib_resource_status_rules.yaml
@@ -247,8 +247,7 @@ rules:
     resourceKind: "Postgres"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -260,8 +259,7 @@ rules:
     resourceKind: "Memcached"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -273,8 +271,7 @@ rules:
     resourceKind: "Valkey"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -286,8 +283,7 @@ rules:
     resourceKind: "Kafka"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -299,8 +295,7 @@ rules:
     resourceKind: "Opensearch"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -312,8 +307,7 @@ rules:
     resourceKind: "HiveMetastore"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -325,8 +319,7 @@ rules:
     resourceKind: "Clickhouse"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -338,8 +331,7 @@ rules:
     resourceKind: "Starrocks"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -351,8 +343,7 @@ rules:
     resourceKind: "Trino"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -364,8 +355,7 @@ rules:
     resourceKind: "Cassandra"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"
@@ -377,8 +367,7 @@ rules:
     resourceKind: "Rabbit"
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
     conditions:
       ready:
         - "True"

--- a/pkg/tracker/generic/contrib_resource_status_rules_ai_test.go
+++ b/pkg/tracker/generic/contrib_resource_status_rules_ai_test.go
@@ -91,9 +91,8 @@ func TestAI_ManagedServicesRulesCoverWhitelistedKinds(t *testing.T) {
 
 		assert.Equal(t, []string{
 			`$.status.conditions[?(@.type=="Available")].status`,
-			`$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status`,
 		}, rule.JSONPaths, "kind %s paths", rule.GroupKind.Kind)
-		assert.Equal(t, "status.conditions[type=Available&&LastValidConfigurationApplied].status", rule.HumanPath, "kind %s human path", rule.GroupKind.Kind)
+		assert.Equal(t, "status.conditions[type=Available].status", rule.HumanPath, "kind %s human path", rule.GroupKind.Kind)
 		assert.Equal(t, casify("True"), rule.ReadyValues, "kind %s ready values", rule.GroupKind.Kind)
 		assert.Empty(t, rule.FailedValues, "kind %s must treat False as progressing", rule.GroupKind.Kind)
 	}

--- a/pkg/tracker/generic/ready_condition_ai_test.go
+++ b/pkg/tracker/generic/ready_condition_ai_test.go
@@ -39,8 +39,8 @@ func condition(conditionType, status string) map[string]interface{} {
 	return map[string]interface{}{"type": conditionType, "status": status}
 }
 
-func TestAI_ManagedServiceReadyWhenBothConditionsTrue(t *testing.T) {
-	object := managedServiceObject("Postgres", condition("Available", "True"), condition("LastValidConfigurationApplied", "True"))
+func TestAI_ManagedServiceReadyWhenAvailableIsTrue(t *testing.T) {
+	object := managedServiceObject("Postgres", condition("Available", "True"))
 
 	indicator, humanPath, err := NewResourceStatusIndicator(object)
 	require.NoError(t, err)
@@ -48,62 +48,49 @@ func TestAI_ManagedServiceReadyWhenBothConditionsTrue(t *testing.T) {
 
 	assert.True(t, indicator.IsReady())
 	assert.False(t, indicator.IsFailed())
-	assert.Equal(t, "True, True", indicator.Value)
-	assert.Equal(t, "status.conditions[type=Available&&LastValidConfigurationApplied].status", humanPath)
+	assert.Equal(t, "True", indicator.Value)
+	assert.Equal(t, "status.conditions[type=Available].status", humanPath)
+}
+
+func TestAI_ManagedServiceReadinessIgnoresOtherConditions(t *testing.T) {
+	object := managedServiceObject("Postgres",
+		condition("Available", "True"),
+		condition("LastValidConfigurationApplied", "False"),
+	)
+
+	indicator, _, err := NewResourceStatusIndicator(object)
+	require.NoError(t, err)
+	require.NotNil(t, indicator)
+
+	assert.True(t, indicator.IsReady(), "only Available decides readiness")
+	assert.False(t, indicator.IsFailed())
+	assert.Equal(t, "True", indicator.Value)
 }
 
 func TestAI_ManagedServiceNotReadyOnNonTrueCondition(t *testing.T) {
 	for _, status := range []string{"False", "Unknown"} {
-		for _, conditionType := range []string{"Available", "LastValidConfigurationApplied"} {
-			t.Run(fmt.Sprintf("%s=%s", conditionType, status), func(t *testing.T) {
-				conditions := []map[string]interface{}{
-					condition("Available", "True"),
-					condition("LastValidConfigurationApplied", "True"),
-				}
-				for i, c := range conditions {
-					if c["type"] == conditionType {
-						conditions[i] = condition(conditionType, status)
-					}
-				}
-
-				indicator, _, err := NewResourceStatusIndicator(managedServiceObject("Postgres", conditions...))
-				require.NoError(t, err)
-				require.NotNil(t, indicator)
-
-				assert.False(t, indicator.IsReady(), "must not be ready")
-				assert.False(t, indicator.IsFailed(), "a non-True condition is progressing, never terminal")
-			})
-		}
-	}
-}
-
-func TestAI_ManagedServicePendingWhenOneConditionMissing(t *testing.T) {
-	for _, testCase := range []struct {
-		name          string
-		conditions    []map[string]interface{}
-		expectedValue string
-	}{
-		{
-			name:          "LastValidConfigurationApplied missing",
-			conditions:    []map[string]interface{}{condition("Available", "True")},
-			expectedValue: "True, -",
-		},
-		{
-			name:          "Available missing",
-			conditions:    []map[string]interface{}{condition("LastValidConfigurationApplied", "True")},
-			expectedValue: "-, True",
-		},
-	} {
-		t.Run(testCase.name, func(t *testing.T) {
-			indicator, _, err := NewResourceStatusIndicator(managedServiceObject("Postgres", testCase.conditions...))
+		t.Run(fmt.Sprintf("Available=%s", status), func(t *testing.T) {
+			indicator, _, err := NewResourceStatusIndicator(managedServiceObject("Postgres", condition("Available", status)))
 			require.NoError(t, err)
 			require.NotNil(t, indicator)
 
-			assert.False(t, indicator.IsReady())
-			assert.False(t, indicator.IsFailed())
-			assert.Equal(t, testCase.expectedValue, indicator.Value)
+			assert.False(t, indicator.IsReady(), "must not be ready")
+			assert.False(t, indicator.IsFailed(), "a non-True condition is progressing, never terminal")
+			assert.Equal(t, status, indicator.Value)
 		})
 	}
+}
+
+func TestAI_ManagedServicePendingWhenAvailableMissing(t *testing.T) {
+	object := managedServiceObject("Postgres", condition("LastValidConfigurationApplied", "True"))
+
+	indicator, _, err := NewResourceStatusIndicator(object)
+	require.NoError(t, err)
+	require.NotNil(t, indicator)
+
+	assert.False(t, indicator.IsReady())
+	assert.False(t, indicator.IsFailed())
+	assert.Empty(t, indicator.Value, "an unresolved rule must keep skipping the value display")
 }
 
 func TestAI_NonWhitelistedKindsInGroupAreNotTracked(t *testing.T) {
@@ -144,13 +131,13 @@ func TestAI_WhitelistedKindStaysPendingUntilConditionsAppear(t *testing.T) {
 	assert.False(t, indicator.IsReady(), "must not go implicitly ready before the operator reports")
 	assert.False(t, indicator.IsFailed())
 	assert.Empty(t, indicator.Value)
-	assert.Equal(t, "status.conditions[type=Available&&LastValidConfigurationApplied].status", humanPath)
+	assert.Equal(t, "status.conditions[type=Available].status", humanPath)
 }
 
 func TestAI_EveryWhitelistedKindIsTracked(t *testing.T) {
 	for _, kind := range managedServicesWhitelistedKinds {
 		t.Run(kind, func(t *testing.T) {
-			object := managedServiceObject(kind, condition("Available", "True"), condition("LastValidConfigurationApplied", "True"))
+			object := managedServiceObject(kind, condition("Available", "True"))
 
 			indicator, _, err := NewResourceStatusIndicator(object)
 			require.NoError(t, err)
@@ -162,7 +149,7 @@ func TestAI_EveryWhitelistedKindIsTracked(t *testing.T) {
 }
 
 func TestAI_ManagedServiceReadyWithLowercaseConditionStatus(t *testing.T) {
-	object := managedServiceObject("Postgres", condition("Available", "true"), condition("LastValidConfigurationApplied", "true"))
+	object := managedServiceObject("Postgres", condition("Available", "true"))
 
 	indicator, _, err := NewResourceStatusIndicator(object)
 	require.NoError(t, err)
@@ -250,8 +237,8 @@ func TestAI_VerdictRequiresEveryPathReadyAndResolved(t *testing.T) {
 }
 
 func TestAI_ConcurrentEvaluationIsDeterministic(t *testing.T) {
-	ready := managedServiceObject("Postgres", condition("Available", "True"), condition("LastValidConfigurationApplied", "True"))
-	pending := managedServiceObject("Valkey", condition("Available", "True"), condition("LastValidConfigurationApplied", "False"))
+	ready := managedServiceObject("Postgres", condition("Available", "True"))
+	pending := managedServiceObject("Valkey", condition("Available", "False"))
 
 	for _, caseInsensitive := range []bool{false, true} {
 		t.Run(fmt.Sprintf("caseInsensitive=%v", caseInsensitive), func(t *testing.T) {


### PR DESCRIPTION
## What

Readiness of `managed-services.deckhouse.io` resources is now determined by the `Available` condition alone. The `LastValidConfigurationApplied` condition is no longer part of the readiness criteria.

Applies to all 11 instance kinds in the group: `Postgres`, `Memcached`, `Valkey`, `Kafka`, `Opensearch`, `HiveMetastore`, `Clickhouse`, `Starrocks`, `Trino`, `Cassandra`, `Rabbit`.

## Why

`LastValidConfigurationApplied` reflects configuration reconciliation, not service availability. Requiring it kept resources in `progressing` even when the service was fully up — either because the operator does not publish that condition at all, or because it stays `False` on an already-serving instance. Readiness tracking would then hang until timeout.

## Changes

`pkg/tracker/generic/contrib_resource_status_rules.yaml`, per kind:

```diff
     jsonPaths:
       - '$.status.conditions[?(@.type=="Available")].status'
-      - '$.status.conditions[?(@.type=="LastValidConfigurationApplied")].status'
-    humanJsonPath: "status.conditions[type=Available&&LastValidConfigurationApplied].status"
+    humanJsonPath: "status.conditions[type=Available].status"
```

The `ready` / `progressing` / `failed` value sets are unchanged: ready on `True`, progressing on `False` and `Unknown`, no terminal failure state.

Tests updated accordingly, plus a new case pinning the intent — `LastValidConfigurationApplied: False` must not block readiness:

- `TestAI_ManagedServiceReadyWhenBothConditionsTrue` → `TestAI_ManagedServiceReadyWhenAvailableIsTrue`
- `TestAI_ManagedServicePendingWhenOneConditionMissing` → `TestAI_ManagedServicePendingWhenAvailableMissing`
- `TestAI_ManagedServiceReadinessIgnoresOtherConditions` (new)

## Notes

- No public API or rule-schema change. The multi-path `jsonPaths` mechanism added in 26a7ce7 stays in place, but after this change no rule uses more than one path. Dropping it back to a single `jsonPath` would be a separate `refactor:`, deliberately not bundled here.
- 26a7ce7 is not in any released tag yet (latest is `v0.13.0`), so no released behavior changes. `nelm` already pins that commit via pseudo-version, which is why this ships as its own commit rather than an amend.

## Testing

```
GOWORK=off go build ./...
GOWORK=off go test -tags ai_tests ./pkg/tracker/generic/
```

Both pass.
